### PR TITLE
feat(vmcp): operator API, registry hot-reload, auth hardening, k8s deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "cursor/**"]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace --lib
+      - run: cargo test -p vmcp --tests
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: vmcp-server ≥96%
+        run: >
+          cargo llvm-cov -p vmcp-server --lib
+          --fail-under-lines 96
+          --ignore-filename-regex '(^|/)(otel_file|proxy|lib|recorder)\.rs$'
+      - name: vmcp-admin ≥99%
+        run: >
+          cargo llvm-cov -p vmcp-admin --lib
+          --fail-under-lines 99
+          --ignore-filename-regex '(integration|ui_regression|pages)\.rs'

--- a/AGENT.md
+++ b/AGENT.md
@@ -26,7 +26,7 @@ upstream MCP-серверы через GraphQL tool `query_graphql` по streama
 | Сборка | `cargo build --workspace` |
 | Юнит-тесты | `cargo test --workspace --lib` |
 | Admin coverage | `cargo llvm-cov -p vmcp-admin --lib --fail-under-lines 99 --ignore-filename-regex '(integration|ui_regression|pages)\.rs'` |
-| Server coverage | `cargo llvm-cov -p vmcp-server --lib --fail-under-lines 93 --ignore-filename-regex '(^|/)(otel_file|proxy|lib|recorder)\.rs$'` |
+| Server coverage | `cargo llvm-cov -p vmcp-server --lib --fail-under-lines 96 --ignore-filename-regex '(^|/)(otel_file|proxy|lib|recorder)\.rs$'` |
 | Coverage CI | `.github/workflows/coverage.yml` — gates выше + PR comment + LCOV + README % badges (`docs/badges/`) |
 | Sessions | JSON в `[recorder].sessions_dir` (`.registry/` + dumps) — см. [`docs/sessions.md`](docs/sessions.md) |
 | Upstream registry | `registry.json` + sidecars + skills/prompts — см. [`docs/upstreams.md`](docs/upstreams.md) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,10 +3700,10 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml",
  "tower",
- "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3740,7 +3740,6 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
- "tracing",
  "vmcp-auth",
  "vmcp-graphql",
  "vmcp-notify",
@@ -3769,30 +3768,24 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",
- "tower-http",
  "tracing",
  "url",
  "uuid",
- "vmcp-config",
 ]
 
 [[package]]
 name = "vmcp-config"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "argon2",
  "figment",
  "serde",
  "thiserror 2.0.18",
  "toml",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -3801,15 +3794,10 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-graphql",
- "futures",
  "rmcp",
- "serde",
  "serde_json",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
- "vmcp-notify",
- "vmcp-registry",
+ "vmcp-auth",
  "vmcp-upstream",
 ]
 
@@ -3822,14 +3810,12 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "vmcp-registry"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "chrono",
  "serde",
  "serde_json",
@@ -3847,10 +3833,10 @@ dependencies = [
  "chrono",
  "dashmap",
  "handlebars 5.1.2",
+ "http",
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",
- "rand 0.8.6",
  "regex",
  "rmcp",
  "rusqlite",
@@ -3863,6 +3849,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "vmcp-auth",
  "vmcp-graphql",
  "vmcp-notify",
  "vmcp-registry",
@@ -3878,10 +3865,8 @@ dependencies = [
  "dashmap",
  "futures",
  "rmcp",
- "serde",
  "serde_json",
  "sqlparser",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "vmcp-notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ handlebars = { version = "5", default-features = false }
 # Auth
 jsonwebtoken = "9"
 argon2 = "0.5"
-subtle = "2"
 rand = "0.8"
 askama = "0.12"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ MCP gateway на Rust. Собирает несколько upstream MCP-серв
 - **Dynamic schema** — строится при старте из upstream `tools/list`.
 - **Tasks (опционально)** — long-running tools как durable tasks на SQLite.
 - **OAuth 2.1 + PKCE + DCR** — или static bearer tokens.
-- **Hot-reload** — токены и промпты обновляются без рестарта.
+- **Hot-reload** — токены, `registry.json` и промпты обновляются без рестарта.
+- **`/api/v1`** — operator Token CRUD + upstreams reload (Bearer `mcp:admin`).
 
 ## Старт
 

--- a/crates/vmcp-admin/Cargo.toml
+++ b/crates/vmcp-admin/Cargo.toml
@@ -24,7 +24,6 @@ async-graphql = { workspace = true }
 dashmap      = { workspace = true }
 parking_lot  = { workspace = true }
 anyhow       = { workspace = true }
-tracing      = { workspace = true }
 askama       = { workspace = true }
 chrono       = { workspace = true }
 futures      = { workspace = true }

--- a/crates/vmcp-auth/Cargo.toml
+++ b/crates/vmcp-auth/Cargo.toml
@@ -5,14 +5,11 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-vmcp-config = { path = "../vmcp-config" }
 axum = { workspace = true }
 tower = { workspace = true }
-tower-http = { workspace = true }
 tokio = { workspace = true }
 jsonwebtoken = { workspace = true }
 argon2 = { workspace = true }
-subtle = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vmcp-auth/src/jwks.rs
+++ b/crates/vmcp-auth/src/jwks.rs
@@ -1,16 +1,24 @@
 //! JWKS keypair + rotation. Two-key window (current + previous) so tokens
 //! issued just before rotation still verify.
+//!
+//! Optional on-disk persistence (`auth.jwks_private_key_pem_path`):
+//! - current PKCS#1 PEM at the configured path
+//! - atomic JSON bundle at `<path>.bundle.json` with current **and previous**
+//!   keys so the rotation window survives pod restarts (G14 / G31).
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use rand::rngs::OsRng;
-use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::pkcs1::{DecodeRsaPrivateKey, EncodeRsaPrivateKey};
 use rsa::pkcs8::EncodePublicKey;
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
+use serde::{Deserialize, Serialize};
 
 use crate::types::JwkPublicKey;
 
@@ -21,6 +29,16 @@ pub struct Keypair {
     pub decoding: DecodingKey,
     /// Public-key components for JWKS (base64url-encoded big-endian, no padding).
     pub jwk: JwkPublicKey,
+    /// PKCS#1 PEM of the private key (for optional disk persistence).
+    pub private_pem: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct JwksBundle {
+    current_kid: String,
+    current_pem: String,
+    previous_kid: Option<String>,
+    previous_pem: Option<String>,
 }
 
 /// The active key set: a current keypair (used to sign) and an optional
@@ -29,22 +47,46 @@ pub struct Keypair {
 pub struct JwksManager {
     pub current: ArcSwap<Keypair>,
     pub previous: ArcSwap<Option<Arc<Keypair>>>,
+    /// When set, `rotate` and first boot write the current private key here.
+    persist_path: Option<PathBuf>,
 }
 
 impl JwksManager {
     /// Generate a fresh keypair and return a manager with no prior key.
-    pub fn new_with_fresh(kid_seed: &str) -> anyhow::Result<Arc<Self>> {
-        let kp = generate_keypair(kid_seed)?;
+    /// Ephemeral — equivalent to [`Self::open`] with `persist = None`.
+    pub fn new_with_fresh(kid_seed: &str) -> Result<Arc<Self>> {
+        Self::open(kid_seed, None)
+    }
+
+    /// Open a manager: load bundle/PEM from `persist` if present, else generate
+    /// (and write when `persist` is `Some`).
+    pub fn open(kid_seed: &str, persist: Option<&Path>) -> Result<Arc<Self>> {
+        let persist_path = persist.map(|p| p.to_path_buf());
+        let (current, previous) = match &persist_path {
+            Some(path) => load_persisted(path, kid_seed)?,
+            None => (generate_keypair(kid_seed)?, None),
+        };
         Ok(Arc::new(Self {
-            current: ArcSwap::from_pointee(kp),
-            previous: ArcSwap::from(Arc::new(None)),
+            current: ArcSwap::from_pointee(current),
+            previous: ArcSwap::from(Arc::new(previous.map(Arc::new))),
+            persist_path,
         }))
     }
 
-    /// Rotate: current → previous, new keypair → current.
-    pub fn rotate(&self, kid_seed: &str) -> anyhow::Result<()> {
+    /// Rotate: current → previous, new keypair → current. Persists atomically
+    /// when configured (bundle JSON + current PEM).
+    pub fn rotate(&self, kid_seed: &str) -> Result<()> {
         let new = generate_keypair(kid_seed)?;
         let old_current = self.current.load_full();
+        if let Some(path) = &self.persist_path {
+            persist_atomic(path, &new, Some(old_current.as_ref()))?;
+            tracing::info!(
+                path = %path.display(),
+                kid = %new.kid,
+                prev_kid = %old_current.kid,
+                "persisted rotated JWKS key bundle"
+            );
+        }
         self.previous.store(Arc::new(Some(old_current)));
         self.current.store(Arc::new(new));
         Ok(())
@@ -96,13 +138,121 @@ impl JwksManager {
     }
 }
 
-fn generate_keypair(kid: &str) -> anyhow::Result<Keypair> {
-    // 2048-bit RSA. Plenty for RS256.
+fn bundle_path(pem_path: &Path) -> PathBuf {
+    let mut p = pem_path.as_os_str().to_os_string();
+    p.push(".bundle.json");
+    PathBuf::from(p)
+}
+
+fn load_persisted(path: &Path, kid_seed: &str) -> Result<(Keypair, Option<Keypair>)> {
+    let bundle_file = bundle_path(path);
+    if bundle_file.exists() {
+        tracing::info!(path = %bundle_file.display(), "loading JWKS key bundle from disk");
+        let text = std::fs::read_to_string(&bundle_file)
+            .with_context(|| format!("read JWKS bundle {}", bundle_file.display()))?;
+        let bundle: JwksBundle = serde_json::from_str(&text)
+            .with_context(|| format!("parse JWKS bundle {}", bundle_file.display()))?;
+        let current = keypair_from_pem_str(&bundle.current_pem, &bundle.current_kid)?;
+        let previous = match (bundle.previous_pem, bundle.previous_kid) {
+            (Some(pem), Some(kid)) => Some(keypair_from_pem_str(&pem, &kid)?),
+            _ => None,
+        };
+        return Ok((current, previous));
+    }
+    if path.exists() {
+        tracing::info!(
+            path = %path.display(),
+            "loading JWKS PEM (no bundle yet; previous empty until next rotation)"
+        );
+        let current = load_keypair_from_pem(path, kid_seed)?;
+        // Migrate to bundle so next rotate persists previous.
+        persist_atomic(path, &current, None)?;
+        return Ok((current, None));
+    }
+    let current = generate_keypair(kid_seed)?;
+    persist_atomic(path, &current, None)?;
+    tracing::info!(
+        path = %path.display(),
+        kid = %current.kid,
+        "wrote new JWKS private key bundle"
+    );
+    Ok((current, None))
+}
+
+/// Atomically write bundle JSON + current PEM (G31).
+fn persist_atomic(pem_path: &Path, current: &Keypair, previous: Option<&Keypair>) -> Result<()> {
+    if let Some(parent) = pem_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create JWKS key dir {}", parent.display()))?;
+        }
+    }
+    let bundle = JwksBundle {
+        current_kid: current.kid.clone(),
+        current_pem: current.private_pem.clone(),
+        previous_kid: previous.map(|p| p.kid.clone()),
+        previous_pem: previous.map(|p| p.private_pem.clone()),
+    };
+    let bundle_file = bundle_path(pem_path);
+    let bundle_tmp = bundle_file.with_extension(format!("json.tmp.{}", std::process::id()));
+    let text = serde_json::to_string_pretty(&bundle)?;
+    std::fs::write(&bundle_tmp, text.as_bytes())
+        .with_context(|| format!("write {}", bundle_tmp.display()))?;
+    set_secret_perms(&bundle_tmp);
+    std::fs::rename(&bundle_tmp, &bundle_file).with_context(|| {
+        format!(
+            "rename {} -> {}",
+            bundle_tmp.display(),
+            bundle_file.display()
+        )
+    })?;
+    set_secret_perms(&bundle_file);
+
+    // Also keep a plain PEM at the configured path for operators/openssl.
+    let pem_tmp = pem_path.with_extension(format!("pem.tmp.{}", std::process::id()));
+    std::fs::write(&pem_tmp, current.private_pem.as_bytes())
+        .with_context(|| format!("write {}", pem_tmp.display()))?;
+    set_secret_perms(&pem_tmp);
+    std::fs::rename(&pem_tmp, pem_path)
+        .with_context(|| format!("rename {} -> {}", pem_tmp.display(), pem_path.display()))?;
+    set_secret_perms(pem_path);
+    Ok(())
+}
+
+fn set_secret_perms(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn generate_keypair(kid: &str) -> Result<Keypair> {
     let mut rng = OsRng;
     let priv_key = RsaPrivateKey::new(&mut rng, 2048)?;
-    let pub_key = priv_key.to_public_key();
+    keypair_from_private(priv_key, kid)
+}
 
-    let pem = priv_key.to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)?;
+fn load_keypair_from_pem(path: &Path, kid: &str) -> Result<Keypair> {
+    let pem = std::fs::read_to_string(path)
+        .with_context(|| format!("read JWKS private key {}", path.display()))?;
+    keypair_from_pem_str(&pem, kid)
+}
+
+fn keypair_from_pem_str(pem: &str, kid: &str) -> Result<Keypair> {
+    let priv_key = RsaPrivateKey::from_pkcs1_pem(pem.trim()).with_context(|| "parse PKCS#1 PEM")?;
+    keypair_from_private(priv_key, kid)
+}
+
+fn keypair_from_private(priv_key: RsaPrivateKey, kid: &str) -> Result<Keypair> {
+    let pub_key = priv_key.to_public_key();
+    let pem = priv_key
+        .to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)?
+        .to_string();
     let pub_pem = pub_key.to_public_key_pem(rsa::pkcs8::LineEnding::LF)?;
     let encoding = EncodingKey::from_rsa_pem(pem.as_bytes())?;
     let decoding = DecodingKey::from_rsa_pem(pub_pem.as_bytes())?;
@@ -122,6 +272,7 @@ fn generate_keypair(kid: &str) -> anyhow::Result<Keypair> {
             n,
             e,
         },
+        private_pem: pem,
     })
 }
 
@@ -133,6 +284,18 @@ fn base64_url(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tokens::{issue_access_token, verify_access_token};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tmp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}-{nanos}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
 
     #[test]
     fn rotate_makes_previous_verifiable() {
@@ -140,11 +303,60 @@ mod tests {
         let initial_kid = mgr.current.load().kid.clone();
         mgr.rotate("b").unwrap();
         assert_eq!(mgr.current.load().kid, "b");
-        // Old key still queryable via previous.
         assert!(mgr.decoding_for(&initial_kid).is_some());
         assert!(mgr.decoding_for("b").is_some());
         assert!(mgr.decoding_for("nope").is_none());
-        // JWKS exposes both.
         assert_eq!(mgr.jwks().len(), 2);
+    }
+
+    #[test]
+    fn persist_survives_reopen_and_verifies_jwt() {
+        let dir = tmp_dir("vmcp-jwks-persist");
+        let path = dir.join("jwks.pem");
+
+        let mgr1 = JwksManager::open("vmcp", Some(&path)).unwrap();
+        let (jwt, _) = issue_access_token(
+            &mgr1,
+            "https://iss",
+            "https://iss/mcp",
+            "client",
+            "mcp:use",
+            3600,
+        )
+        .unwrap();
+        let n1 = mgr1.current.load().jwk.n.clone();
+
+        let mgr2 = JwksManager::open("vmcp", Some(&path)).unwrap();
+        assert_eq!(mgr2.current.load().jwk.n, n1, "same key after reopen");
+        let claims = verify_access_token(&mgr2, &jwt, "https://iss", &["https://iss/mcp"]).unwrap();
+        assert_eq!(claims.client_id, "client");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn previous_key_survives_reopen_after_rotate() {
+        let dir = tmp_dir("vmcp-jwks-prev");
+        let path = dir.join("jwks.pem");
+        let mgr1 = JwksManager::open("vmcp", Some(&path)).unwrap();
+        let (jwt_old, _) = issue_access_token(
+            &mgr1,
+            "https://iss",
+            "https://iss/mcp",
+            "client",
+            "mcp:use",
+            3600,
+        )
+        .unwrap();
+        mgr1.rotate("vmcp-2").unwrap();
+        assert!(bundle_path(&path).exists());
+
+        let mgr2 = JwksManager::open("vmcp-2", Some(&path)).unwrap();
+        assert_eq!(mgr2.jwks().len(), 2);
+        let claims =
+            verify_access_token(&mgr2, &jwt_old, "https://iss", &["https://iss/mcp"]).unwrap();
+        assert_eq!(claims.client_id, "client");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/vmcp-auth/src/lib.rs
+++ b/crates/vmcp-auth/src/lib.rs
@@ -11,11 +11,14 @@ pub mod jwks;
 pub mod middleware;
 pub mod password;
 pub mod router;
+pub mod scopes;
 pub mod state;
 pub mod static_tokens;
 pub mod tokens;
 pub mod types;
 
-pub use middleware::require_bearer;
+pub use scopes::ScopePolicy;
+
+pub use middleware::{require_admin_scope, require_bearer};
 pub use router::build_router;
-pub use state::{AuthState, RenameClientError};
+pub use state::{AuthState, DcrPolicy, RenameClientError};

--- a/crates/vmcp-auth/src/middleware.rs
+++ b/crates/vmcp-auth/src/middleware.rs
@@ -105,6 +105,28 @@ pub fn claims_from_extensions(ext: &axum::http::Extensions) -> Option<&AccessTok
     ext.get::<AccessTokenClaims>()
 }
 
+/// After [`require_bearer`], reject unless claims.scope contains `mcp:admin`.
+/// Intended for `/api/v1/*` control-plane routes.
+pub async fn require_admin_scope(req: Request<Body>, next: Next) -> Response {
+    use crate::static_tokens::{scope_contains, SCOPE_ADMIN};
+
+    match claims_from_extensions(req.extensions()) {
+        Some(claims) if scope_contains(&claims.scope, SCOPE_ADMIN) => next.run(req).await,
+        Some(_) => (StatusCode::FORBIDDEN, "missing scope mcp:admin").into_response(),
+        None => unauthorized_plain("missing_bearer"),
+    }
+}
+
+fn unauthorized_plain(error: &str) -> Response {
+    let challenge = format!("Bearer error=\"{error}\"");
+    let mut resp = (StatusCode::UNAUTHORIZED, error.to_string()).into_response();
+    resp.headers_mut().insert(
+        header::WWW_AUTHENTICATE,
+        challenge.parse().expect("static header value"),
+    );
+    resp
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +256,56 @@ mod tests {
         let resp = app(state).oneshot(bearer_req(&jwt)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(body_string(resp).await, "jwt-client");
+    }
+
+    fn admin_app(state: AuthState) -> Router {
+        Router::new()
+            .route("/api/v1/ping", post(echo_client_id))
+            .layer(axum::middleware::from_fn(require_admin_scope))
+            .layer(axum::middleware::from_fn_with_state(state, require_bearer))
+    }
+
+    fn admin_bearer_req(token: &str) -> Request<Body> {
+        Request::builder()
+            .uri("/api/v1/ping")
+            .method("POST")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn require_admin_scope_allows_mcp_admin_rejects_mcp_use() {
+        let dir = TempDir::new();
+        let file = dir.path().join("tokens.json");
+        let admin = static_tokens::generate_entry("op", Some(static_tokens::SCOPE_ADMIN)).unwrap();
+        let agent = static_tokens::generate_entry("agent", Some("mcp:use")).unwrap();
+        static_tokens::append_atomic(&file, &admin).unwrap();
+        static_tokens::append_atomic(&file, &agent).unwrap();
+        let state = state_with_store(&file);
+
+        let ok = admin_app(state.clone())
+            .oneshot(admin_bearer_req(&admin.token))
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), StatusCode::OK);
+
+        let forbidden = admin_app(state.clone())
+            .oneshot(admin_bearer_req(&agent.token))
+            .await
+            .unwrap();
+        assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+        let missing = admin_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/ping")
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/vmcp-auth/src/password.rs
+++ b/crates/vmcp-auth/src/password.rs
@@ -1,7 +1,6 @@
 //! Master-password hashing/verification via argon2id.
 //!
-//! `verify_master` is constant-time (argon2 returns an Eq-checked digest +
-//! `subtle::ConstantTimeEq` on the encoded hash for the fast-fail prefix path).
+//! `verify_master` uses argon2's password verifier (constant-time digest compare).
 
 use anyhow::{anyhow, Result};
 use argon2::{

--- a/crates/vmcp-auth/src/router.rs
+++ b/crates/vmcp-auth/src/router.rs
@@ -65,7 +65,14 @@ async fn as_metadata(State(s): State<AuthState>) -> Json<AuthorizationServerMeta
         grant_types_supported: vec!["authorization_code"],
         code_challenge_methods_supported: vec!["S256"],
         token_endpoint_auth_methods_supported: vec!["none"],
-        scopes_supported: vec![s.default_scope.clone()],
+        scopes_supported: vec![
+            s.default_scope.clone(),
+            "mcp:admin".into(),
+            "mcp:read".into(),
+            "mcp:write".into(),
+            "upstream:<name>".into(),
+            "deny:<server>.<tool>".into(),
+        ],
         resource_indicators_supported: true,
     })
 }
@@ -115,8 +122,31 @@ async fn register_client(
     State(s): State<AuthState>,
     Json(req): Json<ClientRegistrationRequest>,
 ) -> Result<Json<ClientRegistrationResponse>, AuthError> {
+    if !s.dcr.enabled {
+        return Err(AuthError::Forbidden(
+            "dynamic client registration is disabled".into(),
+        ));
+    }
     if req.redirect_uris.is_empty() {
         return Err(AuthError::BadRequest("redirect_uris required".into()));
+    }
+    for uri in &req.redirect_uris {
+        if !s.dcr.redirect_uri_allowed(uri) {
+            return Err(AuthError::Forbidden(format!(
+                "redirect_uri not allowed by policy: {uri}"
+            )));
+        }
+    }
+
+    // Normalize + validate scope before taking the registration lock.
+    let scope = normalize_oauth_scope(req.scope.as_deref(), &s.default_scope)?;
+
+    let _reg_lock = s.dcr_register_lock.lock().await;
+    if s.dcr.max_clients > 0 && (s.clients.len() as u64) >= s.dcr.max_clients {
+        return Err(AuthError::Forbidden(format!(
+            "DCR client limit reached ({})",
+            s.dcr.max_clients
+        )));
     }
     let client_id = format!("vmcp-{}", Uuid::new_v4());
     let now = Utc::now();
@@ -139,7 +169,7 @@ async fn register_client(
         name,
         grant_types: grant_types.clone(),
         response_types: response_types.clone(),
-        scope: req.scope.clone(),
+        scope: Some(scope.clone()),
         issued_at: now,
     };
     // Persist before the hot-cache insert so a failed write never leaves Cursor
@@ -151,6 +181,13 @@ async fn register_client(
     }
     s.clients.insert(client_id.clone(), info);
 
+    tracing::info!(
+        client_id = %client_id,
+        client_name = ?req.client_name,
+        redirect_uris = ?req.redirect_uris,
+        "DCR client registered"
+    );
+
     Ok(Json(ClientRegistrationResponse {
         client_id,
         redirect_uris: req.redirect_uris,
@@ -158,9 +195,35 @@ async fn register_client(
         token_endpoint_auth_method: req.token_endpoint_auth_method,
         grant_types,
         response_types,
-        scope: req.scope.or_else(|| Some(s.default_scope.clone())),
+        scope: Some(scope),
         client_id_issued_at: now.timestamp(),
     }))
+}
+
+/// Drop `mcp:admin` from DCR/OAuth scopes (G30). Admin is only for
+/// pre-reg / static operator tokens.
+fn sanitize_dcr_scope(scope: &str) -> String {
+    scope
+        .split_whitespace()
+        .filter(|t| *t != "mcp:admin")
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Sanitize + validate OAuth scope for DCR/authorize. Empty after strip → default.
+fn normalize_oauth_scope(
+    requested: Option<&str>,
+    default_scope: &str,
+) -> Result<String, AuthError> {
+    let raw = requested.unwrap_or(default_scope);
+    let cleaned = sanitize_dcr_scope(raw);
+    let scope = if cleaned.is_empty() {
+        default_scope.to_string()
+    } else {
+        cleaned
+    };
+    crate::scopes::validate_scope_string(&scope).map_err(AuthError::BadRequest)?;
+    Ok(scope)
 }
 
 #[derive(Debug, Deserialize)]
@@ -198,8 +261,8 @@ async fn authorize(
     if !client.redirect_uris.iter().any(|r| r == &p.redirect_uri) {
         return Err(AuthError::BadRequest("redirect_uri mismatch".into()));
     }
-    let scope = p.scope.clone().unwrap_or_else(|| s.default_scope.clone());
     drop(client);
+    let scope = normalize_oauth_scope(p.scope.as_deref(), &s.default_scope)?;
 
     let consent = ConsentSession {
         id: format!("cs-{}", Uuid::new_v4()),
@@ -549,5 +612,137 @@ mod tests {
         assert_eq!(html_escape("<script>"), "&lt;script&gt;");
         assert_eq!(html_escape("a&b"), "a&amp;b");
         assert_eq!(html_escape("\"x\""), "&quot;x&quot;");
+    }
+
+    fn test_auth_state() -> AuthState {
+        use crate::jwks::JwksManager;
+        let jwks = JwksManager::new_with_fresh("kid").unwrap();
+        AuthState::new(
+            jwks,
+            "https://iss.example",
+            "https://iss.example/mcp",
+            3600,
+            "$argon2id$v=19$m=19456,t=2,p=1$YWFhYWFhYWFhYWFhYWFhYQ$dG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4",
+        )
+    }
+
+    async fn post_register(
+        state: AuthState,
+        body: serde_json::Value,
+    ) -> axum::http::Response<axum::body::Body> {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        build_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn dcr_disabled_forbids_register() {
+        use crate::state::DcrPolicy;
+        let state = test_auth_state().with_dcr_policy(DcrPolicy {
+            enabled: false,
+            max_clients: 0,
+            redirect_uri_allowlist: vec![],
+        });
+        let resp = post_register(
+            state,
+            serde_json::json!({
+                "client_name": "x",
+                "redirect_uris": ["http://127.0.0.1/cb"]
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn dcr_allowlist_rejects_foreign_redirect() {
+        use crate::state::DcrPolicy;
+        let state = test_auth_state().with_dcr_policy(DcrPolicy {
+            enabled: true,
+            max_clients: 10,
+            redirect_uri_allowlist: vec!["http://127.0.0.1".into()],
+        });
+        let resp = post_register(
+            state,
+            serde_json::json!({
+                "client_name": "x",
+                "redirect_uris": ["https://evil.example/cb"]
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn dcr_max_clients_enforced() {
+        use crate::state::DcrPolicy;
+        let state = test_auth_state().with_dcr_policy(DcrPolicy {
+            enabled: true,
+            max_clients: 1,
+            redirect_uri_allowlist: vec![],
+        });
+        let ok = post_register(
+            state.clone(),
+            serde_json::json!({
+                "client_name": "one",
+                "redirect_uris": ["http://127.0.0.1/cb"]
+            }),
+        )
+        .await;
+        assert_eq!(ok.status(), StatusCode::OK);
+        let denied = post_register(
+            state,
+            serde_json::json!({
+                "client_name": "two",
+                "redirect_uris": ["http://127.0.0.1/cb2"]
+            }),
+        )
+        .await;
+        assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn dcr_admin_only_scope_falls_back_to_default() {
+        let state = test_auth_state();
+        let resp = post_register(
+            state,
+            serde_json::json!({
+                "client_name": "adminish",
+                "redirect_uris": ["http://127.0.0.1/cb"],
+                "scope": "mcp:admin"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1 << 16)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["scope"], "mcp:use");
+    }
+
+    #[tokio::test]
+    async fn dcr_rejects_malformed_scope_tokens() {
+        let state = test_auth_state();
+        let resp = post_register(
+            state,
+            serde_json::json!({
+                "client_name": "bad",
+                "redirect_uris": ["http://127.0.0.1/cb"],
+                "scope": "mcp:use deny:broken"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/vmcp-auth/src/scopes.rs
+++ b/crates/vmcp-auth/src/scopes.rs
@@ -1,0 +1,217 @@
+//! OAuth scope policy for MCP / GraphQL authorization.
+//!
+//! Scope string is space-separated (OAuth). Semantics:
+//! - `mcp:use` — full access (legacy god-scope, backward compatible)
+//! - `mcp:admin` — control-plane (`/api/v1`); also implies full MCP access
+//! - `mcp:read` — Query / read_only tools only
+//! - `mcp:write` — Query + Mutation
+//! - `upstream:<name>` — whitelist that GraphQL namespace / proxy server
+//! - `deny:<server>.<tool>` — deny-list on top of grants
+//!
+//! If no `upstream:*` tokens are present, all upstreams are allowed (subject to
+//! read/write + deny). Empty scope → deny all (except when auth is off and no
+//! claims are attached — callers treat missing policy as allow).
+
+use std::collections::HashSet;
+
+use crate::static_tokens::SCOPE_ADMIN;
+
+/// Validate a space-separated scope string. Unknown tokens are rejected so a
+/// typo cannot silently become deny-all at runtime (G10).
+pub fn validate_scope_string(scope: &str) -> Result<(), String> {
+    let mut any = false;
+    for tok in scope.split_whitespace() {
+        any = true;
+        if matches!(tok, "mcp:use" | "mcp:admin" | "mcp:read" | "mcp:write") {
+            continue;
+        }
+        if let Some(name) = tok.strip_prefix("upstream:") {
+            if !name.is_empty()
+                && name
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+            {
+                continue;
+            }
+            return Err(format!("invalid upstream scope token: {tok}"));
+        }
+        if let Some(rest) = tok.strip_prefix("deny:") {
+            let mut parts = rest.splitn(2, '.');
+            let server = parts.next().unwrap_or("");
+            let tool = parts.next().unwrap_or("");
+            if !server.is_empty()
+                && !tool.is_empty()
+                && server
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+                && tool
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+            {
+                continue;
+            }
+            return Err(format!("invalid deny scope token: {tok}"));
+        }
+        return Err(format!("unknown scope token: {tok}"));
+    }
+    if !any {
+        return Err("scope must not be empty".into());
+    }
+    Ok(())
+}
+
+/// Parsed authorization policy from a token/JWT `scope` claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopePolicy {
+    pub full: bool,
+    pub read: bool,
+    pub write: bool,
+    /// When non-empty, only these upstream names are allowed.
+    pub upstreams: HashSet<String>,
+    /// Denied tools as `"server.tool"` keys.
+    pub deny: HashSet<String>,
+}
+
+impl ScopePolicy {
+    /// Parse a space-separated OAuth scope string.
+    pub fn parse(scope: &str) -> Self {
+        let mut full = false;
+        let mut read = false;
+        let mut write = false;
+        let mut upstreams = HashSet::new();
+        let mut deny = HashSet::new();
+
+        for tok in scope.split_whitespace() {
+            match tok {
+                "mcp:use" | SCOPE_ADMIN => full = true,
+                "mcp:read" => read = true,
+                "mcp:write" => {
+                    read = true;
+                    write = true;
+                }
+                s if s.starts_with("upstream:") => {
+                    let name = &s["upstream:".len()..];
+                    if !name.is_empty() {
+                        upstreams.insert(name.to_string());
+                    }
+                }
+                s if s.starts_with("deny:") => {
+                    let rest = &s["deny:".len()..];
+                    if rest.contains('.') {
+                        deny.insert(rest.to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Full access implies read+write and no upstream whitelist restriction
+        // from the full flag itself (whitelist still applies if present).
+        if full {
+            read = true;
+            write = true;
+        }
+
+        Self {
+            full,
+            read,
+            write,
+            upstreams,
+            deny,
+        }
+    }
+
+    /// Authorize a tool call. `is_write` is true for Mutation / non-readOnly tools.
+    pub fn authorize(&self, server: &str, tool: &str, is_write: bool) -> Result<(), String> {
+        let key = format!("{server}.{tool}");
+        if self.deny.contains(&key) {
+            return Err(format!("scope denies {key}"));
+        }
+        if !self.upstreams.is_empty() && !self.upstreams.contains(server) {
+            return Err(format!("scope does not grant upstream:{server}"));
+        }
+        if self.full {
+            return Ok(());
+        }
+        if is_write {
+            if self.write {
+                return Ok(());
+            }
+            return Err("scope lacks mcp:write (mutation / non-readOnly tool)".into());
+        }
+        if self.read || self.write {
+            return Ok(());
+        }
+        Err("scope lacks mcp:read / mcp:use".into())
+    }
+
+    /// Whether this policy may use the given upstream at all (for discovery filters).
+    pub fn allows_upstream(&self, server: &str) -> bool {
+        self.upstreams.is_empty() || self.upstreams.contains(server)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_use_is_full_access() {
+        let p = ScopePolicy::parse("mcp:use");
+        assert!(p.authorize("time", "now", true).is_ok());
+        assert!(p.authorize("postgres", "query", true).is_ok());
+    }
+
+    #[test]
+    fn mcp_admin_is_full_access() {
+        let p = ScopePolicy::parse("mcp:admin");
+        assert!(p.authorize("time", "now", false).is_ok());
+    }
+
+    #[test]
+    fn read_blocks_write() {
+        let p = ScopePolicy::parse("mcp:read");
+        assert!(p.authorize("time", "now", false).is_ok());
+        assert!(p.authorize("time", "set", true).is_err());
+    }
+
+    #[test]
+    fn write_allows_read_and_write() {
+        let p = ScopePolicy::parse("mcp:write");
+        assert!(p.authorize("time", "now", false).is_ok());
+        assert!(p.authorize("time", "set", true).is_ok());
+    }
+
+    #[test]
+    fn upstream_whitelist() {
+        let p = ScopePolicy::parse("mcp:use upstream:time");
+        assert!(p.authorize("time", "now", false).is_ok());
+        assert!(p.authorize("postgres", "query", false).is_err());
+        assert!(p.allows_upstream("time"));
+        assert!(!p.allows_upstream("postgres"));
+    }
+
+    #[test]
+    fn deny_list() {
+        let p = ScopePolicy::parse("mcp:use deny:postgres.query");
+        assert!(p.authorize("postgres", "list", false).is_ok());
+        assert!(p.authorize("postgres", "query", false).is_err());
+    }
+
+    #[test]
+    fn empty_scope_denies() {
+        let p = ScopePolicy::parse("");
+        assert!(p.authorize("time", "now", false).is_err());
+    }
+
+    #[test]
+    fn validate_scope_string_accepts_known_and_rejects_junk() {
+        assert!(validate_scope_string("mcp:use").is_ok());
+        assert!(validate_scope_string("mcp:read upstream:time").is_ok());
+        assert!(validate_scope_string("mcp:use deny:postgres.query").is_ok());
+        assert!(validate_scope_string("").is_err());
+        assert!(validate_scope_string("mcp:root").is_err());
+        assert!(validate_scope_string("upstream:").is_err());
+        assert!(validate_scope_string("deny:onlyserver").is_err());
+    }
+}

--- a/crates/vmcp-auth/src/state.rs
+++ b/crates/vmcp-auth/src/state.rs
@@ -19,7 +19,7 @@ use crate::types::{
     ConsentSession,
 };
 
-/// Auth configuration extracted from [`vmcp_config::AuthConfig`] + public URL.
+/// Runtime auth state built from gateway config (`auth.*` + public URL).
 #[derive(Clone)]
 pub struct AuthState {
     pub jwks: Arc<JwksManager>,
@@ -51,6 +51,82 @@ pub struct AuthState {
     /// flow is then the only way onto `/mcp`. Wrapped in `Arc` so `AuthState`
     /// stays `Clone` (the inner `ArcSwap` is not `Clone`).
     pub token_store: Option<Arc<StaticTokenStore>>,
+
+    /// Dynamic Client Registration policy (from `auth.dcr_*` config).
+    pub dcr: DcrPolicy,
+
+    /// Serializes `POST /register` so `dcr_max_clients` checks are atomic (G28).
+    pub dcr_register_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+/// Limits for `POST /register`. Defaults match historical open registration.
+#[derive(Debug, Clone)]
+pub struct DcrPolicy {
+    pub enabled: bool,
+    /// `0` = unlimited.
+    pub max_clients: u64,
+    /// Prefix allowlist; empty = allow any redirect_uri.
+    pub redirect_uri_allowlist: Vec<String>,
+}
+
+impl Default for DcrPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_clients: 0,
+            redirect_uri_allowlist: Vec::new(),
+        }
+    }
+}
+
+impl DcrPolicy {
+    /// Whether `uri` is permitted by the allowlist.
+    ///
+    /// Entries that parse as URLs match on **exact host** + scheme. Port is
+    /// checked only when the allowlist entry specifies one. Path on the
+    /// allowlist entry (if not `/`) is a required prefix. Custom-scheme
+    /// prefixes like `cursor://` still use starts-with. Rejects
+    /// `http://127.0.0.1.evil/...` when allowlist has `http://127.0.0.1` (G27).
+    pub fn redirect_uri_allowed(&self, uri: &str) -> bool {
+        if self.redirect_uri_allowlist.is_empty() {
+            return true;
+        }
+        let Ok(parsed) = url::Url::parse(uri) else {
+            return false;
+        };
+        self.redirect_uri_allowlist.iter().any(|entry| {
+            if entry.is_empty() {
+                return false;
+            }
+            if let Ok(allowed) = url::Url::parse(entry) {
+                // `cursor://` parses with empty host — treat as scheme prefix.
+                if allowed.host_str().is_none() {
+                    return uri.starts_with(entry.as_str());
+                }
+                if parsed.scheme() != allowed.scheme() {
+                    return false;
+                }
+                if parsed.host_str() != allowed.host_str() {
+                    return false;
+                }
+                // Explicit port on allowlist → must match; otherwise any port OK.
+                if let Some(p) = allowed.port() {
+                    if parsed.port() != Some(p) {
+                        return false;
+                    }
+                }
+                let allow_path = allowed.path();
+                if allow_path.is_empty() || allow_path == "/" {
+                    return true;
+                }
+                let path = parsed.path();
+                return path == allow_path
+                    || path.starts_with(&format!("{}/", allow_path.trim_end_matches('/')));
+            }
+            // Unparseable allow entries: literal prefix.
+            uri.starts_with(entry.as_str())
+        })
+    }
 }
 
 impl AuthState {
@@ -75,7 +151,14 @@ impl AuthState {
             consents: Arc::new(DashMap::new()),
             client_store: None,
             token_store: None,
+            dcr: DcrPolicy::default(),
+            dcr_register_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
+    }
+
+    pub fn with_dcr_policy(mut self, dcr: DcrPolicy) -> Self {
+        self.dcr = dcr;
+        self
     }
 
     /// Attach a durable DCR client store and hydrate the in-memory cache.
@@ -292,5 +375,22 @@ mod tests {
             msg.contains(db.to_string_lossy().as_ref()),
             "error should include the db path: {msg}"
         );
+    }
+
+    #[test]
+    fn dcr_redirect_allowlist_host_match_not_prefix_host() {
+        let open = DcrPolicy::default();
+        assert!(open.redirect_uri_allowed("https://evil.example/cb"));
+
+        let locked = DcrPolicy {
+            enabled: true,
+            max_clients: 10,
+            redirect_uri_allowlist: vec!["http://127.0.0.1".into(), "cursor://".into()],
+        };
+        assert!(locked.redirect_uri_allowed("http://127.0.0.1:9999/cb"));
+        assert!(locked.redirect_uri_allowed("cursor://anysphere.cursor-mcp/oauth/callback"));
+        assert!(!locked.redirect_uri_allowed("https://evil.example/cb"));
+        // Prefix-host attack must fail (G27).
+        assert!(!locked.redirect_uri_allowed("http://127.0.0.1.evil.example/cb"));
     }
 }

--- a/crates/vmcp-auth/src/static_tokens.rs
+++ b/crates/vmcp-auth/src/static_tokens.rs
@@ -107,18 +107,10 @@ impl StaticTokenStore {
 }
 
 /// Read the JSON-array file into a `token -> TokenInfo` map. Missing/empty file
-/// -> empty map. Malformed JSON -> error (caller decides whether to keep old).
+/// -> empty map. Malformed JSON / oversize -> error (caller keeps previous set).
+/// Uses the same size/count caps as [`read_entries`] (Bugbot: reload bypasses caps).
 fn read_map(path: &Path) -> Result<HashMap<String, TokenInfo>> {
-    if !path.exists() {
-        return Ok(HashMap::new());
-    }
-    let text = std::fs::read_to_string(path)
-        .with_context(|| format!("read token file {}", path.display()))?;
-    if text.trim().is_empty() {
-        return Ok(HashMap::new());
-    }
-    let entries: Vec<StaticTokenEntry> = serde_json::from_str(&text)
-        .with_context(|| format!("parse token file {}", path.display()))?;
+    let entries = read_entries(path)?;
     let mut map = HashMap::with_capacity(entries.len());
     for e in entries {
         map.insert(
@@ -142,12 +134,22 @@ pub fn valid_id(s: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
+/// OAuth/static scope `mcp:admin` — required for `/api/v1` control-plane.
+pub const SCOPE_ADMIN: &str = "mcp:admin";
+
+/// Space-separated OAuth scope string contains `needle` as a whole token.
+pub fn scope_contains(scope: &str, needle: &str) -> bool {
+    scope.split_whitespace().any(|s| s == needle)
+}
+
 /// Generate a fresh eternal token entry. `client_id` is derived from `name`
 /// (validated); `scope` defaults to `mcp:use`.
 pub fn generate_entry(name: &str, scope: Option<&str>) -> Result<StaticTokenEntry> {
     if !valid_id(name) {
         anyhow::bail!("name must be 1..=128 chars of [A-Za-z0-9_-] (used as client_id): {name:?}");
     }
+    let scope = scope.unwrap_or("mcp:use").to_string();
+    crate::scopes::validate_scope_string(&scope).map_err(|e| anyhow::anyhow!(e))?;
     let mut raw = [0u8; 32];
     rand::rngs::OsRng.fill_bytes(&mut raw);
     let token = format!(
@@ -158,46 +160,56 @@ pub fn generate_entry(name: &str, scope: Option<&str>) -> Result<StaticTokenEntr
         token,
         client_id: name.to_string(),
         name: Some(name.to_string()),
-        scope: scope.unwrap_or("mcp:use").to_string(),
+        scope,
         issued_at: Utc::now(),
     })
 }
 
-/// Append `entry` to the JSON-array token file atomically (tmp + rename),
-/// creating the parent dir if needed. Reads the existing array first; if it's
-/// present but malformed this FAILS LOUDLY rather than clobbering tokens. On
-/// unix the file gets `0600` perms (it holds bearer secrets).
-///
-/// Concurrent `pre-reg` runs are not supported (last writer wins on rename);
-/// the CLI is operator-driven and run one at a time.
-pub fn append_atomic(path: &Path, entry: &StaticTokenEntry) -> Result<()> {
+/// Soft cap against huge token files (G33).
+pub const MAX_TOKENS: usize = 10_000;
+/// Soft cap on tokens.json size (bytes).
+pub const MAX_TOKENS_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Read the JSON-array token file. Missing/empty → empty vec. Malformed → error.
+pub fn read_entries(path: &Path) -> Result<Vec<StaticTokenEntry>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let meta =
+        std::fs::metadata(path).with_context(|| format!("stat token file {}", path.display()))?;
+    if meta.len() > MAX_TOKENS_FILE_BYTES {
+        anyhow::bail!(
+            "token file {} is {} bytes; max is {MAX_TOKENS_FILE_BYTES}",
+            path.display(),
+            meta.len()
+        );
+    }
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("read token file {}", path.display()))?;
+    if text.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let entries: Vec<StaticTokenEntry> = serde_json::from_str(&text)
+        .with_context(|| format!("parse token file {}", path.display()))?;
+    if entries.len() > MAX_TOKENS {
+        anyhow::bail!(
+            "token file has {} entries; max is {MAX_TOKENS}",
+            entries.len()
+        );
+    }
+    Ok(entries)
+}
+
+/// Atomically replace the whole token file (tmp + rename). Creates parent dirs.
+/// On unix the file gets `0600` perms.
+pub fn write_all_atomic(path: &Path, entries: &[StaticTokenEntry]) -> Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("create token dir {}", parent.display()))?;
         }
     }
-
-    let mut entries: Vec<StaticTokenEntry> = if path.exists() {
-        let text = std::fs::read_to_string(path)
-            .with_context(|| format!("read token file {}", path.display()))?;
-        if text.trim().is_empty() {
-            Vec::new()
-        } else {
-            serde_json::from_str(&text).with_context(|| {
-                format!(
-                    "existing token file {} is malformed; refusing to overwrite",
-                    path.display()
-                )
-            })?
-        }
-    } else {
-        Vec::new()
-    };
-    entries.push(entry.clone());
-
-    let text = serde_json::to_string_pretty(&entries)?;
-    // pid-suffixed tmp so a stray concurrent run is less likely to collide.
+    let text = serde_json::to_string_pretty(entries)?;
     let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
     std::fs::write(&tmp, text.as_bytes()).with_context(|| format!("write {}", tmp.display()))?;
     set_secret_perms(&tmp);
@@ -205,6 +217,102 @@ pub fn append_atomic(path: &Path, entry: &StaticTokenEntry) -> Result<()> {
         .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
     set_secret_perms(path);
     Ok(())
+}
+
+/// Append `entry` to the JSON-array token file atomically (tmp + rename),
+/// creating the parent dir if needed. Reads the existing array first; if it's
+/// present but malformed this FAILS LOUDLY rather than clobbering tokens.
+///
+/// Concurrent `pre-reg` runs are not supported (last writer wins on rename);
+/// the CLI is operator-driven and run one at a time.
+pub fn append_atomic(path: &Path, entry: &StaticTokenEntry) -> Result<()> {
+    let mut entries = read_entries(path).with_context(|| {
+        format!(
+            "existing token file {} is malformed; refusing to overwrite",
+            path.display()
+        )
+    })?;
+    entries.push(entry.clone());
+    write_all_atomic(path, &entries)
+}
+
+/// True if any entry's scope includes [`SCOPE_ADMIN`].
+pub fn count_admin_entries(entries: &[StaticTokenEntry]) -> usize {
+    entries
+        .iter()
+        .filter(|e| scope_contains(&e.scope, SCOPE_ADMIN))
+        .count()
+}
+
+/// Remove the entry with `client_id`. Returns `Ok(true)` if something was
+/// removed. Refuses to remove the last `mcp:admin` token (`Ok(false)` is not
+/// used for that — returns [`RevokeError`]).
+/// Replace the token secret for an existing `client_id`, keeping name/scope.
+/// Returns the new entry (full secret) or `None` if not found.
+pub fn rotate_by_client_id(path: &Path, client_id: &str) -> Result<Option<StaticTokenEntry>> {
+    let mut entries = read_entries(path)?;
+    let Some(idx) = entries.iter().position(|e| e.client_id == client_id) else {
+        return Ok(None);
+    };
+    let mut raw = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut raw);
+    entries[idx].token = format!(
+        "{TOKEN_PREFIX}{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw)
+    );
+    entries[idx].issued_at = Utc::now();
+    let entry = entries[idx].clone();
+    write_all_atomic(path, &entries)?;
+    Ok(Some(entry))
+}
+
+pub fn revoke_by_client_id(path: &Path, client_id: &str) -> Result<RevokeOutcome> {
+    let mut entries = read_entries(path)?;
+    let idx = match entries.iter().position(|e| e.client_id == client_id) {
+        Some(i) => i,
+        None => return Ok(RevokeOutcome::NotFound),
+    };
+    let removing_admin = scope_contains(&entries[idx].scope, SCOPE_ADMIN);
+    if removing_admin && count_admin_entries(&entries) <= 1 {
+        return Ok(RevokeOutcome::LastAdmin);
+    }
+    entries.remove(idx);
+    write_all_atomic(path, &entries)?;
+    Ok(RevokeOutcome::Revoked)
+}
+
+/// Result of [`revoke_by_client_id`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevokeOutcome {
+    Revoked,
+    NotFound,
+    /// Would leave the file with zero `mcp:admin` tokens.
+    LastAdmin,
+}
+
+/// Redacted view for list APIs — never includes the full secret.
+#[derive(Debug, Clone, Serialize)]
+pub struct TokenListItem {
+    pub client_id: String,
+    pub name: Option<String>,
+    pub scope: String,
+    pub issued_at: DateTime<Utc>,
+    /// `vmcp_` + first 4 chars of the secret payload (or shorter if tiny).
+    pub token_prefix: String,
+}
+
+impl StaticTokenEntry {
+    pub fn to_list_item(&self) -> TokenListItem {
+        let rest = self.token.strip_prefix(TOKEN_PREFIX).unwrap_or(&self.token);
+        let head: String = rest.chars().take(4).collect();
+        TokenListItem {
+            client_id: self.client_id.clone(),
+            name: self.name.clone(),
+            scope: self.scope.clone(),
+            issued_at: self.issued_at,
+            token_prefix: format!("{TOKEN_PREFIX}{head}"),
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -362,5 +470,66 @@ mod tests {
             append_atomic(&f, &e).is_err(),
             "append must fail loudly on a malformed existing file"
         );
+    }
+
+    #[test]
+    fn scope_contains_splits_on_whitespace() {
+        assert!(scope_contains("mcp:use mcp:admin", SCOPE_ADMIN));
+        assert!(!scope_contains("mcp:use", SCOPE_ADMIN));
+        assert!(!scope_contains("mcp:adminx", SCOPE_ADMIN));
+    }
+
+    #[test]
+    fn load_respects_token_file_size_cap() {
+        let dir = TempDir::new();
+        let f = dir.path().join("tokens.json");
+        // Just over the soft cap (metadata size checked before parse).
+        let huge = "x".repeat((MAX_TOKENS_FILE_BYTES as usize) + 8);
+        std::fs::write(&f, &huge).unwrap();
+        let err = match StaticTokenStore::load(&f) {
+            Ok(_) => panic!("expected size cap error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("max is"),
+            "expected size cap error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn revoke_by_client_id_and_last_admin_guard() {
+        let dir = TempDir::new();
+        let f = dir.path().join("tokens.json");
+        let admin = generate_entry("operator", Some(SCOPE_ADMIN)).unwrap();
+        let agent = generate_entry("agent", Some("mcp:use")).unwrap();
+        write_all_atomic(&f, &[admin.clone(), agent.clone()]).unwrap();
+
+        assert_eq!(
+            revoke_by_client_id(&f, "agent").unwrap(),
+            RevokeOutcome::Revoked
+        );
+        assert_eq!(read_entries(&f).unwrap().len(), 1);
+        assert_eq!(
+            revoke_by_client_id(&f, "operator").unwrap(),
+            RevokeOutcome::LastAdmin,
+            "must not delete the last mcp:admin"
+        );
+        assert_eq!(read_entries(&f).unwrap().len(), 1);
+        assert_eq!(
+            revoke_by_client_id(&f, "missing").unwrap(),
+            RevokeOutcome::NotFound
+        );
+    }
+
+    #[test]
+    fn list_item_redacts_secret() {
+        let e = generate_entry("ci", None).unwrap();
+        let item = e.to_list_item();
+        assert!(item.token_prefix.starts_with(TOKEN_PREFIX));
+        assert!(
+            item.token_prefix.len() < e.token.len(),
+            "prefix must be shorter than full token"
+        );
+        assert_ne!(item.token_prefix, e.token);
     }
 }

--- a/crates/vmcp-auth/src/static_tokens.rs
+++ b/crates/vmcp-auth/src/static_tokens.rs
@@ -197,6 +197,24 @@ pub fn read_entries(path: &Path) -> Result<Vec<StaticTokenEntry>> {
             entries.len()
         );
     }
+    // Same scope rules as mint/API — reject typos on disk load/hot-reload so
+    // ScopePolicy::parse cannot silently drop unknown tokens.
+    for (i, e) in entries.iter().enumerate() {
+        if !valid_id(&e.client_id) {
+            anyhow::bail!(
+                "token file {}: entry[{i}] invalid client_id {:?}",
+                path.display(),
+                e.client_id
+            );
+        }
+        crate::scopes::validate_scope_string(&e.scope).map_err(|err| {
+            anyhow::anyhow!(
+                "token file {}: entry[{i}] client_id={}: {err}",
+                path.display(),
+                e.client_id
+            )
+        })?;
+    }
     Ok(entries)
 }
 
@@ -494,6 +512,40 @@ mod tests {
             err.to_string().contains("max is"),
             "expected size cap error, got: {err}"
         );
+    }
+
+    #[test]
+    fn load_and_reload_reject_invalid_scope_on_disk() {
+        let dir = TempDir::new();
+        let f = dir.path().join("tokens.json");
+        let good = generate_entry("ci", Some("mcp:use")).unwrap();
+        append_atomic(&f, &good).unwrap();
+        let store = StaticTokenStore::load(&f).unwrap();
+        assert!(store.lookup(&good.token).is_some());
+
+        // Hand-edit a bad scope into the file.
+        std::fs::write(
+            &f,
+            r#"[{
+              "token": "vmcp_deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+              "client_id": "bad",
+              "name": "bad",
+              "scope": "mcp:use deny:broken",
+              "issued_at": "2020-01-01T00:00:00Z"
+            }]"#,
+        )
+        .unwrap();
+        assert!(
+            read_entries(&f).is_err(),
+            "read_entries must reject invalid deny: token"
+        );
+        // Hot-reload keeps the previous good set on parse/validation failure.
+        store.reload(&f);
+        assert!(
+            store.lookup(&good.token).is_some(),
+            "reload must keep previous set when disk scope is invalid"
+        );
+        assert_eq!(store.len(), 1);
     }
 
     #[test]

--- a/crates/vmcp-config/Cargo.toml
+++ b/crates/vmcp-config/Cargo.toml
@@ -8,10 +8,7 @@ license.workspace = true
 serde = { workspace = true }
 figment = { workspace = true }
 toml = { workspace = true }
-anyhow = { workspace = true }
 thiserror = { workspace = true }
-url = { workspace = true }
-tracing = { workspace = true }
 # Parse the master-password PHC hash at config-load time so a malformed or
 # placeholder hash fails fast at boot instead of during the OAuth consent flow.
 argon2 = { workspace = true }

--- a/crates/vmcp-config/src/lib.rs
+++ b/crates/vmcp-config/src/lib.rs
@@ -305,6 +305,22 @@ pub struct AuthConfig {
     /// Same idea as `[tasks].db_path`. Override via `VMCP_AUTH__CLIENTS_DB_PATH`.
     #[serde(default = "AuthConfig::default_clients_db_path")]
     pub clients_db_path: PathBuf,
+    /// When false, `POST /register` returns 403 (pre-reg / static tokens still work).
+    #[serde(default = "AuthConfig::default_dcr_enabled")]
+    pub dcr_enabled: bool,
+    /// Max durable DCR clients (`0` = unlimited). Excess registrations → 403.
+    #[serde(default)]
+    pub dcr_max_clients: u64,
+    /// If non-empty, each `redirect_uri` must start with one of these prefixes
+    /// (e.g. `http://127.0.0.1`, `cursor://`). Empty = allow any URI (legacy).
+    #[serde(default)]
+    pub dcr_redirect_uri_allowlist: Vec<String>,
+    /// Optional PKCS#1 PEM path for the JWT signing key. When set, the key is
+    /// loaded at boot (or generated + written `0600` if missing) so access
+    /// tokens survive restarts. Unset = ephemeral in-memory JWKS (historical).
+    /// Override via `VMCP_AUTH__JWKS_PRIVATE_KEY_PEM_PATH`.
+    #[serde(default)]
+    pub jwks_private_key_pem_path: Option<PathBuf>,
 }
 
 impl AuthConfig {
@@ -323,6 +339,9 @@ impl AuthConfig {
     fn default_clients_db_path() -> PathBuf {
         PathBuf::from("state/clients.db")
     }
+    fn default_dcr_enabled() -> bool {
+        true
+    }
 }
 
 impl Default for AuthConfig {
@@ -336,6 +355,10 @@ impl Default for AuthConfig {
             issuer: None,
             tokens_file: None,
             clients_db_path: Self::default_clients_db_path(),
+            dcr_enabled: Self::default_dcr_enabled(),
+            dcr_max_clients: 0,
+            dcr_redirect_uri_allowlist: Vec::new(),
+            jwks_private_key_pem_path: None,
         }
     }
 }

--- a/crates/vmcp-graphql/Cargo.toml
+++ b/crates/vmcp-graphql/Cargo.toml
@@ -5,15 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-vmcp-registry = { path = "../vmcp-registry" }
 vmcp-upstream = { path = "../vmcp-upstream" }
-vmcp-notify   = { path = "../vmcp-notify" }
+vmcp-auth     = { path = "../vmcp-auth" }
 async-graphql = { workspace = true }
 rmcp = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
-futures = { workspace = true }
-tokio = { workspace = true }

--- a/crates/vmcp-graphql/src/lib.rs
+++ b/crates/vmcp-graphql/src/lib.rs
@@ -888,6 +888,7 @@ fn build_namespace_object(
             None => (None, Arc::new(HashMap::new())),
         };
 
+        let is_write = suffix == "Write";
         let mut field = Field::new(
             field_name,
             TypeRef::named_nn("ToolCallResult"),
@@ -897,7 +898,17 @@ fn build_namespace_object(
                 let pool = pool_for_tool.clone();
                 let args_map = args_map_for_tool.clone();
                 let args_json = collect_args(&ctx, &args_map);
+                let denied = ctx
+                    .data_opt::<vmcp_auth::ScopePolicy>()
+                    .and_then(|p| p.authorize(&server, &tool, is_write).err());
                 FieldFuture::new(async move {
+                    if let Some(msg) = denied {
+                        return Ok(Some(FieldValue::owned_any(ToolCallNode {
+                            is_error: true,
+                            text: Some(format!("forbidden: {msg}")),
+                            json: Value::Null,
+                        })));
+                    }
                     let res = pool.call(&server, &tool, args_json).await;
                     let node = match res {
                         Ok(r) => result_to_node(r, max_response_bytes, cap_mode),

--- a/crates/vmcp-notify/Cargo.toml
+++ b/crates/vmcp-notify/Cargo.toml
@@ -10,4 +10,3 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }
 chrono = { workspace = true }
-tracing = { workspace = true }

--- a/crates/vmcp-registry/Cargo.toml
+++ b/crates/vmcp-registry/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-anyhow = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }

--- a/crates/vmcp-registry/src/lib.rs
+++ b/crates/vmcp-registry/src/lib.rs
@@ -190,12 +190,18 @@ pub enum RegistryError {
     Io(#[from] std::io::Error),
     #[error("parse: {0}")]
     Parse(#[from] serde_json::Error),
+    #[error("env: {0}")]
+    Env(String),
+    #[error("duplicate upstream name: {0}")]
+    DuplicateName(String),
 }
 
 /// Expand `${VAR}` / `$VAR` placeholders from the process environment.
-/// Unset variables become an empty string. Used for HTTP upstream `url` /
-/// `bearer` so secrets stay in `.env` instead of `registry.json`.
-pub fn expand_env(input: &str) -> String {
+///
+/// Missing variables are an **error** (strict) so a typo cannot silently
+/// produce `https://host//mcp` or drop a bearer. Used for HTTP upstream
+/// `url` / `bearer` / `env`.
+pub fn expand_env(input: &str) -> Result<String, RegistryError> {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
@@ -209,7 +215,10 @@ pub fn expand_env(input: &str) -> String {
             if let Some(end) = input[i + 2..].find('}') {
                 let key = &input[i + 2..i + 2 + end];
                 if !key.is_empty() && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-                    out.push_str(&std::env::var(key).unwrap_or_default());
+                    let val = std::env::var(key).map_err(|_| {
+                        RegistryError::Env(format!("environment variable `{key}` is not set"))
+                    })?;
+                    out.push_str(&val);
                     i += 3 + end;
                     continue;
                 }
@@ -227,38 +236,66 @@ pub fn expand_env(input: &str) -> String {
             .sum::<usize>();
         if len > 0 {
             let key = &rest[..len];
-            out.push_str(&std::env::var(key).unwrap_or_default());
+            let val = std::env::var(key).map_err(|_| {
+                RegistryError::Env(format!("environment variable `{key}` is not set"))
+            })?;
+            out.push_str(&val);
             i += 1 + len;
         } else {
             out.push('$');
             i += 1;
         }
     }
-    out
+    Ok(out)
 }
 
-fn expand_upstream(spec: &mut UpstreamSpec) {
+fn expand_upstream(spec: &mut UpstreamSpec) -> Result<(), RegistryError> {
     if let Some(url) = spec.url.as_mut() {
-        *url = expand_env(url);
+        *url = expand_env(url)?;
     }
     if let Some(bearer) = spec.bearer.as_mut() {
-        let expanded = expand_env(bearer);
+        let expanded = expand_env(bearer)?;
         if expanded.is_empty() {
+            tracing::warn!(
+                upstream = %spec.name,
+                "bearer expanded to empty; dropping Authorization header"
+            );
             spec.bearer = None;
         } else {
             *bearer = expanded;
         }
     }
     for v in spec.env.values_mut() {
-        *v = expand_env(v);
+        *v = expand_env(v)?;
     }
+    Ok(())
+}
+
+/// Soft cap against accidental huge registries (G33).
+pub const MAX_UPSTREAMS: usize = 256;
+
+fn reject_duplicate_names(registry: &Registry) -> Result<(), RegistryError> {
+    if registry.upstreams.len() > MAX_UPSTREAMS {
+        return Err(RegistryError::Env(format!(
+            "too many upstreams ({}); max is {MAX_UPSTREAMS}",
+            registry.upstreams.len()
+        )));
+    }
+    let mut seen = std::collections::HashSet::new();
+    for u in &registry.upstreams {
+        if !seen.insert(u.name.as_str()) {
+            return Err(RegistryError::DuplicateName(u.name.clone()));
+        }
+    }
+    Ok(())
 }
 
 /// Load the registry JSON. Returns an empty registry if the file is absent —
 /// vmcp can boot with no upstreams (useful for OAuth-only deploys).
 ///
 /// After parse, expands `${ENV}` placeholders in each upstream's `url`,
-/// `bearer`, and `env` values.
+/// `bearer`, and `env` values. Duplicate `name`s are rejected. Missing env
+/// vars in placeholders are a hard error.
 pub fn load_registry(path: &Path) -> Result<Registry, RegistryError> {
     if !path.exists() {
         tracing::warn!(
@@ -269,8 +306,9 @@ pub fn load_registry(path: &Path) -> Result<Registry, RegistryError> {
     }
     let text = fs::read_to_string(path)?;
     let mut registry: Registry = serde_json::from_str(&text)?;
+    reject_duplicate_names(&registry)?;
     for upstream in &mut registry.upstreams {
-        expand_upstream(upstream);
+        expand_upstream(upstream)?;
     }
     Ok(registry)
 }
@@ -439,24 +477,51 @@ mod tests {
         std::env::set_var("VMCP_TEST_EXPAND_A", "alpha");
         std::env::set_var("VMCP_TEST_EXPAND_B", "beta");
         assert_eq!(
-            expand_env("https://ex/${VMCP_TEST_EXPAND_A}/mcp"),
+            expand_env("https://ex/${VMCP_TEST_EXPAND_A}/mcp").unwrap(),
             "https://ex/alpha/mcp"
         );
-        assert_eq!(expand_env("tok-$VMCP_TEST_EXPAND_B-end"), "tok-beta-end");
-        assert_eq!(expand_env("no/${VMCP_TEST_EXPAND_MISSING}/x"), "no//x");
+        assert_eq!(
+            expand_env("tok-$VMCP_TEST_EXPAND_B-end").unwrap(),
+            "tok-beta-end"
+        );
+        let err = expand_env("no/${VMCP_TEST_EXPAND_MISSING}/x").unwrap_err();
+        assert!(
+            err.to_string().contains("VMCP_TEST_EXPAND_MISSING"),
+            "missing env must hard-fail, got: {err}"
+        );
         std::env::remove_var("VMCP_TEST_EXPAND_A");
         std::env::remove_var("VMCP_TEST_EXPAND_B");
+    }
+
+    #[test]
+    fn load_registry_rejects_duplicate_names() {
+        let p = tmp_path("reg-dup");
+        fs::write(
+            &p,
+            r#"{"upstreams":[
+              {"name":"a","transport":"http","url":"http://127.0.0.1:1/mcp"},
+              {"name":"a","transport":"http","url":"http://127.0.0.1:2/mcp"}
+            ]}"#,
+        )
+        .unwrap();
+        let err = load_registry(&p).unwrap_err();
+        assert!(
+            matches!(err, RegistryError::DuplicateName(ref n) if n == "a"),
+            "got: {err}"
+        );
+        let _ = fs::remove_file(&p);
     }
 
     #[test]
     fn load_registry_expands_bearer_and_drops_empty() {
         let p = tmp_path("reg-expand");
         std::env::set_var("VMCP_TEST_BEARER", "secret-tok");
+        std::env::set_var("VMCP_TEST_EMPTY_BEARER", "");
         fs::write(
             &p,
             r#"{"upstreams":[
               {"name":"a","transport":"http","url":"https://ex/${VMCP_TEST_BEARER}/mcp","bearer":"${VMCP_TEST_BEARER}"},
-              {"name":"b","transport":"http","url":"https://ex/mcp","bearer":"${VMCP_TEST_MISSING}"}
+              {"name":"b","transport":"http","url":"https://ex/mcp","bearer":"${VMCP_TEST_EMPTY_BEARER}"}
             ]}"#,
         )
         .unwrap();
@@ -468,6 +533,7 @@ mod tests {
         assert_eq!(r.upstreams[0].bearer.as_deref(), Some("secret-tok"));
         assert_eq!(r.upstreams[1].bearer, None);
         std::env::remove_var("VMCP_TEST_BEARER");
+        std::env::remove_var("VMCP_TEST_EMPTY_BEARER");
         cleanup(&[p]);
     }
 

--- a/crates/vmcp-server/Cargo.toml
+++ b/crates/vmcp-server/Cargo.toml
@@ -13,6 +13,8 @@ vmcp-upstream = { path = "../vmcp-upstream" }
 vmcp-notify   = { path = "../vmcp-notify" }
 vmcp-graphql  = { path = "../vmcp-graphql" }
 vmcp-registry = { path = "../vmcp-registry" }
+vmcp-auth     = { path = "../vmcp-auth" }
+http = "1"
 rmcp = { workspace = true }
 async-graphql = { workspace = true }
 tokio = { workspace = true }
@@ -31,7 +33,6 @@ regex = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 chrono = { workspace = true }
-rand = { workspace = true }
 rusqlite = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/vmcp-server/src/lib.rs
+++ b/crates/vmcp-server/src/lib.rs
@@ -66,10 +66,10 @@ pub use prompt_catalog::prompt_source_handlers;
 pub type SchemaHandle = Arc<ArcSwap<Schema>>;
 
 /// Async hook invoked on upstream `notifications/tools/list_changed`
-/// (argument = upstream source name). Wired by the binary to refresh tools +
-/// rebuild GraphQL.
+/// (argument = upstream source name). Returns `true` when cache + GraphQL were
+/// updated successfully — only then should clients be notified.
 pub type ToolsChangedHook =
-    Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+    Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = bool> + Send>> + Send + Sync>;
 
 /// Hot-swappable skills handle. The admin API mutates the on-disk yaml
 /// files, reloads `Vec<Skill>` from disk, and `.store()`s the new pointee
@@ -333,12 +333,23 @@ impl VmcpServer {
                                 );
                             }
                         }
+                        let mut forward = true;
                         if n.method == "notifications/tools/list_changed" {
                             if let Some(hook) = on_tools_changed.as_ref() {
-                                hook(n.source.clone()).await;
+                                // Only tell clients tools changed after gateway
+                                // cache + schema successfully catch up.
+                                forward = hook(n.source.clone()).await;
+                                if !forward {
+                                    tracing::warn!(
+                                        upstream = %n.source,
+                                        "skipping tools/list_changed forward; refresh/schema failed"
+                                    );
+                                }
                             }
                         }
-                        forward_to_peers(&peers, &n).await;
+                        if forward {
+                            forward_to_peers(&peers, &n).await;
+                        }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
@@ -642,6 +653,12 @@ impl ServerHandler for VmcpServer {
             ));
         }
         let (server, tool, args) = parse_run_task_args(request.arguments)?;
+        if let Some(policy) = scope_policy_from_request_context(&context) {
+            // Same write-capable check as synchronous run_task.
+            if let Err(msg) = policy.authorize(&server, &tool, true) {
+                return Err(McpError::invalid_params(format!("forbidden: {msg}"), None));
+            }
+        }
         let owner = task_owner(&context);
         t.runner
             .enqueue(owner, server, tool, args)

--- a/crates/vmcp-server/src/lib.rs
+++ b/crates/vmcp-server/src/lib.rs
@@ -16,6 +16,8 @@
 #![allow(clippy::result_large_err)]
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -62,6 +64,12 @@ pub use prompt_catalog::prompt_source_handlers;
 /// by the drift-handler in the bin is visible to in-flight tool calls
 /// here.
 pub type SchemaHandle = Arc<ArcSwap<Schema>>;
+
+/// Async hook invoked on upstream `notifications/tools/list_changed`
+/// (argument = upstream source name). Wired by the binary to refresh tools +
+/// rebuild GraphQL.
+pub type ToolsChangedHook =
+    Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 /// Hot-swappable skills handle. The admin API mutates the on-disk yaml
 /// files, reloads `Vec<Skill>` from disk, and `.store()`s the new pointee
@@ -138,12 +146,19 @@ fn build_run_task_tool() -> Tool {
     tool
 }
 
-/// Owner key for task context-binding.
+/// Owner key for task context-binding (G26).
 ///
-/// Phase 1 runs single-tenant: every requestor shares the `"anon"` bucket, so
-/// task IDs (UUID) are the access-control mechanism. Per-requestor binding can
-/// be layered on later by extracting an identity from `context`.
-fn task_owner(_context: &RequestContext<RoleServer>) -> String {
+/// Prefer Bearer `client_id` from the HTTP request Parts injected by rmcp
+/// streamable-http. Falls back to `"anon"` only when auth is off / missing.
+fn task_owner(context: &RequestContext<RoleServer>) -> String {
+    use vmcp_auth::types::AccessTokenClaims;
+    if let Some(parts) = context.extensions.get::<http::request::Parts>() {
+        if let Some(claims) = parts.extensions.get::<AccessTokenClaims>() {
+            if !claims.client_id.is_empty() {
+                return claims.client_id.clone();
+            }
+        }
+    }
     "anon".to_string()
 }
 
@@ -288,6 +303,16 @@ impl VmcpServer {
     /// on notifications they understand (e.g. `tools/list_changed`); others are
     /// delivered best-effort.
     pub fn spawn_notification_forwarder(&self) {
+        self.spawn_notification_forwarder_with_tools_hook(None);
+    }
+
+    /// Like [`spawn_notification_forwarder`], but invokes `on_tools_changed(source)`
+    /// *before* forwarding `notifications/tools/list_changed` so the gateway can
+    /// refresh the tool cache + rebuild GraphQL (bin wires this to registry reload).
+    pub fn spawn_notification_forwarder_with_tools_hook(
+        &self,
+        on_tools_changed: Option<ToolsChangedHook>,
+    ) {
         let peers = self.inner.peers.clone();
         let bus = self.inner.pool.bus();
         let pool = self.inner.pool.clone();
@@ -296,9 +321,9 @@ impl VmcpServer {
             loop {
                 match rx.recv().await {
                     Ok(n) => {
-                        // Refresh the prompt cache *before* forwarding so a
-                        // client that re-lists / getPrompt immediately after
-                        // the notification sees the post-drift catalogue.
+                        // Refresh caches *before* forwarding so a client that
+                        // re-lists immediately after the notification sees the
+                        // post-drift catalogue.
                         if n.method == "notifications/prompts/list_changed" {
                             if let Err(e) = pool.refresh_prompts(&n.source).await {
                                 tracing::warn!(
@@ -306,6 +331,11 @@ impl VmcpServer {
                                     error = %e,
                                     "failed to refresh prompts after list_changed"
                                 );
+                            }
+                        }
+                        if n.method == "notifications/tools/list_changed" {
+                            if let Some(hook) = on_tools_changed.as_ref() {
+                                hook(n.source.clone()).await;
                             }
                         }
                         forward_to_peers(&peers, &n).await;
@@ -326,6 +356,11 @@ impl VmcpServer {
     /// Schema handle clone — useful for the bin to install drift callbacks.
     pub fn schema_handle(&self) -> SchemaHandle {
         self.inner.schema.clone()
+    }
+
+    /// Task runner when native MCP tasks are enabled.
+    pub fn task_runner(&self) -> Option<Arc<TaskRunner>> {
+        self.inner.tasks.as_ref().map(|t| t.runner.clone())
     }
 
     #[tool(
@@ -416,6 +451,7 @@ Args: `query` (required GraphQL document), `variables` (optional JSON object), `
     async fn query_graphql(
         &self,
         Parameters(args): Parameters<QueryGraphqlArgs>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         if let Err(e) = vmcp_graphql::validation::pre_validate(&args.query) {
             return Ok(CallToolResult::error(vec![Content::text(format!(
@@ -431,6 +467,9 @@ Args: `query` (required GraphQL document), `variables` (optional JSON object), `
         if let Some(op) = args.operation_name {
             req = req.operation_name(op);
         }
+        if let Some(policy) = scope_policy_from_request_context(&context) {
+            req = req.data(policy);
+        }
         let resp = schema_guard.execute(req).await;
         let body = serde_json::to_value(&resp)
             .unwrap_or_else(|e| json!({"errors": [{"message": format!("serialize: {e}")}]}));
@@ -438,6 +477,18 @@ Args: `query` (required GraphQL document), `variables` (optional JSON object), `
             body.to_string(),
         )]))
     }
+}
+
+/// Pull Bearer claims (injected by axum `require_bearer`) out of the HTTP
+/// request Parts that rmcp streamable-http places on MCP request extensions.
+pub(crate) fn scope_policy_from_request_context(
+    context: &RequestContext<RoleServer>,
+) -> Option<vmcp_auth::ScopePolicy> {
+    use vmcp_auth::types::AccessTokenClaims;
+
+    let parts = context.extensions.get::<http::request::Parts>()?;
+    let claims = parts.extensions.get::<AccessTokenClaims>()?;
+    Some(vmcp_auth::ScopePolicy::parse(&claims.scope))
 }
 
 impl VmcpServer {
@@ -462,6 +513,8 @@ impl ServerHandler for VmcpServer {
             .enable_tool_list_changed()
             .enable_prompts()
             .enable_prompts_list_changed()
+            // Upstream + task lifecycle logs arrive as `notifications/message`.
+            .enable_logging()
             .build();
         // Native MCP Tasks (SEP-1686) — only when `run_task` is wired.
         if self.inner.tasks.is_some() {
@@ -549,6 +602,14 @@ impl ServerHandler for VmcpServer {
                 return Err(McpError::invalid_params("run_task is not enabled", None));
             };
             let (server, tool, args) = parse_run_task_args(request.arguments)?;
+            if let Some(policy) = scope_policy_from_request_context(&context) {
+                // Tasks are treated as write-capable (side effects / long-running).
+                if let Err(msg) = policy.authorize(&server, &tool, true) {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "forbidden: {msg}"
+                    ))]));
+                }
+            }
             return match t.runner.run_now(&server, &tool, args).await {
                 Ok(r) => Ok(r),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!("{e:#}"))])),

--- a/crates/vmcp-server/src/prompt_proxy.rs
+++ b/crates/vmcp-server/src/prompt_proxy.rs
@@ -196,4 +196,81 @@ mod tests {
         assert_eq!(out.get("ok"), Some(&Value::String("true".into())));
         assert_eq!(out.get("q"), Some(&Value::String("hi".into())));
     }
+
+    #[test]
+    fn catalogue_prompt_without_description_and_without_args() {
+        let bus = Bus::new(8);
+        let pool = UpstreamPool::empty_for_test(bus);
+        pool.insert_synthetic_prompts_for_test(
+            "svc",
+            None,
+            vec![],
+            vec![ResolvedPrompt {
+                server: "svc".into(),
+                name: "bare".into(),
+                description: None,
+                arguments: vec![],
+            }],
+        );
+        let listed = catalogue_from_pool(&pool);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "svc__bare");
+        assert!(listed[0].arguments.is_none());
+        assert_eq!(listed[0].description.as_deref(), Some("[svc] bare"));
+    }
+
+    #[test]
+    fn inject_inserts_message_when_first_content_is_non_text() {
+        use rmcp::model::RawImageContent;
+        let tools = vec![ResolvedTool {
+            server: "demo".into(),
+            name: "echo_tool".into(),
+            description: None,
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: true,
+            task_support: TaskSupportHint::Forbidden,
+        }];
+        let img = PromptMessage::new(
+            PromptMessageRole::User,
+            PromptMessageContent::Image {
+                image: rmcp::model::Annotated {
+                    raw: RawImageContent {
+                        data: "aaa".into(),
+                        mime_type: "image/png".into(),
+                        meta: None,
+                    },
+                    annotations: None,
+                },
+            },
+        );
+        let upstream = GetPromptResult::new(vec![img]);
+        let out = inject_into_result("demo", &tools, upstream);
+        assert!(out.messages.len() >= 2);
+        match &out.messages[0].content {
+            PromptMessageContent::Text { text } => {
+                assert!(text.contains("## vmcp GraphQL routing"));
+            }
+            other => panic!("expected injected text first, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inject_creates_message_when_upstream_empty() {
+        let tools = vec![ResolvedTool {
+            server: "demo".into(),
+            name: "t".into(),
+            description: None,
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: true,
+            task_support: TaskSupportHint::Forbidden,
+        }];
+        let out = inject_into_result("demo", &tools, GetPromptResult::new(vec![]));
+        assert_eq!(out.messages.len(), 1);
+        match &out.messages[0].content {
+            PromptMessageContent::Text { text } => {
+                assert!(text.contains("Query.demo.t"));
+            }
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
 }

--- a/crates/vmcp-server/src/proxy.rs
+++ b/crates/vmcp-server/src/proxy.rs
@@ -90,7 +90,7 @@ impl ServerHandler for ProxyServer {
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _ctx: RequestContext<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let (server, tool) = request.name.split_once(NAME_SEP).ok_or_else(|| {
             McpError::invalid_params(
@@ -101,6 +101,20 @@ impl ServerHandler for ProxyServer {
                 None,
             )
         })?;
+
+        if let Some(policy) = crate::scope_policy_from_request_context(&ctx) {
+            let is_write = self
+                .pool
+                .resolved(server)
+                .and_then(|tools| tools.into_iter().find(|t| t.name == tool))
+                .map(|t| !t.read_only)
+                .unwrap_or(true);
+            if let Err(msg) = policy.authorize(server, tool, is_write) {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "forbidden: {msg}"
+                ))]));
+            }
+        }
 
         let args = match request.arguments {
             Some(obj) => Value::Object(obj),

--- a/crates/vmcp-server/src/tasks.rs
+++ b/crates/vmcp-server/src/tasks.rs
@@ -18,13 +18,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use rmcp::model::{
-    CancelTaskResult, CreateTaskResult, GetTaskResult, ListTasksResult, Task, TaskStatus,
+    CancelTaskResult, CreateTaskResult, GetTaskResult, ListTasksResult, LoggingLevel,
+    LoggingMessageNotificationParam, Task, TaskStatus,
 };
 use rusqlite::{params, Connection, OptionalExtension};
-use serde_json::Value;
+use serde_json::{json, Value};
 use tokio::sync::{Notify, Semaphore};
 use uuid::Uuid;
 
+use vmcp_notify::Bus;
 use vmcp_upstream::UpstreamPool;
 
 /// MCP tool name for the task-capable upstream proxy.
@@ -453,6 +455,7 @@ pub type TaskToolKey = (String, String);
 pub struct TaskRunner {
     store: Arc<TaskStore>,
     pool: Arc<UpstreamPool>,
+    bus: Arc<Bus>,
     sem: Arc<Semaphore>,
     /// Only these upstream tools may be invoked via `run_task`.
     allowed: Arc<std::sync::RwLock<HashSet<TaskToolKey>>>,
@@ -462,6 +465,7 @@ pub struct TaskRunner {
 impl TaskRunner {
     pub fn new(
         pool: Arc<UpstreamPool>,
+        bus: Arc<Bus>,
         db_path: PathBuf,
         allowlist: HashSet<TaskToolKey>,
         max_concurrent: usize,
@@ -472,6 +476,7 @@ impl TaskRunner {
         Ok(Self {
             store,
             pool,
+            bus,
             sem: Arc::new(Semaphore::new(max_concurrent.max(1))),
             allowed: Arc::new(std::sync::RwLock::new(allowlist)),
             db_path,
@@ -542,34 +547,86 @@ impl TaskRunner {
         let task_id = self.store.create(&owner, &server, &tool)?;
         let store = self.store.clone();
         let pool = self.pool.clone();
+        let bus = self.bus.clone();
         let sem = self.sem.clone();
         let id = task_id.clone();
-        let server_bg = server;
-        let tool_bg = tool;
+        let server_bg = server.clone();
+        let tool_bg = tool.clone();
+
+        publish_task_log(
+            &self.bus,
+            &task_id,
+            LoggingLevel::Info,
+            format!("task enqueued for {server}.{tool}"),
+            json!({ "status": "working", "server": server, "tool": tool }),
+        );
 
         tokio::spawn(async move {
             let _permit = match sem.acquire().await {
                 Ok(p) => p,
                 Err(_) => {
                     store.fail(&id, "task semaphore closed", None);
+                    publish_task_log(
+                        &bus,
+                        &id,
+                        LoggingLevel::Error,
+                        "task semaphore closed",
+                        json!({ "status": "failed" }),
+                    );
                     return;
                 }
             };
             if store.is_cancelled(&id) {
+                publish_task_log(
+                    &bus,
+                    &id,
+                    LoggingLevel::Warning,
+                    "task cancelled before upstream call",
+                    json!({ "status": "cancelled" }),
+                );
                 return;
             }
+            publish_task_log(
+                &bus,
+                &id,
+                LoggingLevel::Debug,
+                format!("calling upstream {server_bg}.{tool_bg}"),
+                json!({ "status": "working", "server": server_bg, "tool": tool_bg }),
+            );
             match pool.call(&server_bg, &tool_bg, args).await {
                 Ok(result) => {
                     let is_error = result.is_error.unwrap_or(false);
                     let payload = serde_json::to_value(&result).unwrap_or(Value::Null);
                     if is_error {
                         store.fail(&id, "upstream tool reported isError=true", Some(payload));
+                        publish_task_log(
+                            &bus,
+                            &id,
+                            LoggingLevel::Error,
+                            "upstream tool reported isError=true",
+                            json!({ "status": "failed", "server": server_bg, "tool": tool_bg }),
+                        );
                     } else {
                         store.complete(&id, payload, Some("Upstream tool completed.".into()));
+                        publish_task_log(
+                            &bus,
+                            &id,
+                            LoggingLevel::Info,
+                            "upstream tool completed",
+                            json!({ "status": "completed", "server": server_bg, "tool": tool_bg }),
+                        );
                     }
                 }
                 Err(e) => {
-                    store.fail(&id, format!("upstream call failed: {e:#}"), None);
+                    let msg = format!("upstream call failed: {e:#}");
+                    store.fail(&id, msg.clone(), None);
+                    publish_task_log(
+                        &bus,
+                        &id,
+                        LoggingLevel::Error,
+                        msg,
+                        json!({ "status": "failed", "server": server_bg, "tool": tool_bg }),
+                    );
                 }
             }
         });
@@ -583,6 +640,33 @@ impl TaskRunner {
             });
         Ok(CreateTaskResult::new(task))
     }
+}
+
+/// Emit MCP `notifications/message` for task lifecycle (forwarded to clients).
+fn publish_task_log(
+    bus: &Bus,
+    task_id: &str,
+    level: LoggingLevel,
+    message: impl Into<String>,
+    extra: Value,
+) {
+    let mut data = match extra {
+        Value::Object(map) => map,
+        other => {
+            let mut m = serde_json::Map::new();
+            m.insert("extra".into(), other);
+            m
+        }
+    };
+    data.insert("message".into(), Value::String(message.into()));
+    data.insert("taskId".into(), Value::String(task_id.to_string()));
+    let params = LoggingMessageNotificationParam {
+        level,
+        logger: Some(format!("tasks/{task_id}")),
+        data: Value::Object(data),
+    };
+    let value = serde_json::to_value(&params).unwrap_or(Value::Null);
+    bus.publish("tasks", "notifications/message", value);
 }
 
 /// Collect `(server, tool)` pairs that are task-capable from the live pool.
@@ -781,7 +865,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let db = dir.path().join("tasks.db");
         let bus = vmcp_notify::Bus::new(16);
-        let pool = Arc::new(UpstreamPool::empty_for_test(bus));
+        let pool = Arc::new(UpstreamPool::empty_for_test(bus.clone()));
         pool.insert_synthetic_for_test(
             "mock",
             None,
@@ -794,7 +878,7 @@ mod tests {
                 task_support: vmcp_registry::TaskSupportHint::Optional,
             }],
         );
-        let runner = TaskRunner::new(pool, db, keys, 2, 60_000, 100).unwrap();
+        let runner = TaskRunner::new(pool, bus, db, keys, 2, 60_000, 100).unwrap();
         (dir, runner)
     }
 
@@ -826,6 +910,24 @@ mod tests {
         assert!(err.to_string().contains("not task-capable"));
     }
 
+    #[test]
+    fn publish_task_log_accepts_non_object_extra() {
+        let bus = Bus::new(8);
+        let mut rx = bus.subscribe();
+        publish_task_log(
+            &bus,
+            "tid-1",
+            LoggingLevel::Info,
+            "hello",
+            Value::String("not-an-object".into()),
+        );
+        let n = rx.try_recv().expect("log published");
+        assert_eq!(n.method, "notifications/message");
+        assert_eq!(n.params["data"]["extra"], "not-an-object");
+        assert_eq!(n.params["data"]["taskId"], "tid-1");
+        assert_eq!(n.params["logger"], "tasks/tid-1");
+    }
+
     #[tokio::test]
     async fn runner_enqueue_rejects_then_fails_missing_upstream_client() {
         let mut keys = HashSet::new();
@@ -834,6 +936,7 @@ mod tests {
         let err = runner.enqueue("anon".into(), "nope".into(), "x".into(), Value::Null);
         assert!(matches!(err, Err(TaskError::NotFound(_))));
 
+        let mut rx = runner.bus.subscribe();
         let created = runner
             .enqueue(
                 "anon".into(),
@@ -843,6 +946,22 @@ mod tests {
             )
             .unwrap();
         assert_eq!(created.task.status, TaskStatus::Working);
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("log timeout")
+            .expect("log recv");
+        assert_eq!(first.method, "notifications/message");
+        assert_eq!(first.source, "tasks");
+        assert!(
+            first.params["logger"]
+                .as_str()
+                .unwrap_or("")
+                .starts_with("tasks/"),
+            "logger={}",
+            first.params["logger"]
+        );
+
         // Synthetic pool has no live client → background call fails → Failed.
         let payload = runner
             .store()

--- a/crates/vmcp-upstream/Cargo.toml
+++ b/crates/vmcp-upstream/Cargo.toml
@@ -10,10 +10,8 @@ vmcp-notify   = { path = "../vmcp-notify" }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 dashmap = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/vmcp-upstream/src/lib.rs
+++ b/crates/vmcp-upstream/src/lib.rs
@@ -639,6 +639,7 @@ impl UpstreamPool {
     }
 
     /// Snapshot of raw + resolved tools for rollback after a failed schema rebuild.
+    #[allow(clippy::type_complexity)]
     pub fn tools_snapshot(&self, server: &str) -> Option<(Arc<Vec<Tool>>, Arc<Vec<ResolvedTool>>)> {
         let sess = self.sessions.get(server)?;
         Some((sess.tools.load_full(), sess.resolved.load_full()))

--- a/crates/vmcp-upstream/src/lib.rs
+++ b/crates/vmcp-upstream/src/lib.rs
@@ -638,6 +638,27 @@ impl UpstreamPool {
         info!(upstream = %name, "upstream upserted into pool");
     }
 
+    /// Snapshot of raw + resolved tools for rollback after a failed schema rebuild.
+    pub fn tools_snapshot(&self, server: &str) -> Option<(Arc<Vec<Tool>>, Arc<Vec<ResolvedTool>>)> {
+        let sess = self.sessions.get(server)?;
+        Some((sess.tools.load_full(), sess.resolved.load_full()))
+    }
+
+    /// Restore tools caches after a failed post-refresh schema rebuild.
+    pub fn restore_tools(
+        &self,
+        server: &str,
+        tools: Arc<Vec<Tool>>,
+        resolved: Arc<Vec<ResolvedTool>>,
+    ) -> bool {
+        let Some(sess) = self.sessions.get(server) else {
+            return false;
+        };
+        sess.tools.store(tools);
+        sess.resolved.store(resolved);
+        true
+    }
+
     /// Re-run `tools/list` + sidecar merge for one upstream (list_changed path).
     pub async fn refresh_tools(
         &self,

--- a/crates/vmcp-upstream/src/lib.rs
+++ b/crates/vmcp-upstream/src/lib.rs
@@ -10,9 +10,9 @@
 
 mod sql_guard;
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
 use arc_swap::ArcSwap;
@@ -87,7 +87,8 @@ pub struct UpstreamPool {
 
 /// One live stdio upstream.
 pub struct UpstreamSession {
-    pub spec: UpstreamSpec,
+    /// Hot-swappable registry entry (description can change without respawn).
+    pub spec: ArcSwap<UpstreamSpec>,
     /// Owned client handle. Dropped on shutdown.
     pub client: Mutex<Option<RunningService<RoleClient, ForwardingClient>>>,
     /// Raw rmcp Tool list (mostly diagnostic — we mostly read from `resolved`).
@@ -99,7 +100,42 @@ pub struct UpstreamSession {
     pub prompts: ArcSwap<Vec<ResolvedPrompt>>,
     /// Per-session call mutex (defence-in-depth, rmcp already serialises).
     pub call_lock: Mutex<()>,
+    /// Last observed liveness: updated on successful/failed RPC. Advisory for
+    /// `/api/v1/upstreams` + `/ready` — call paths still retry while a client
+    /// handle exists.
     pub connected: AtomicBool,
+    /// Last transport/RPC error message (cleared on success).
+    pub last_error: ArcSwap<Option<String>>,
+    /// Unix ms of last successful RPC (0 = never).
+    pub last_ok_unix_ms: AtomicU64,
+}
+
+impl UpstreamSession {
+    fn mark_ok(&self) {
+        self.connected.store(true, Ordering::Relaxed);
+        self.last_error.store(Arc::new(None));
+        self.last_ok_unix_ms.store(unix_ms_now(), Ordering::Relaxed);
+    }
+
+    fn mark_err(&self, err: impl ToString) {
+        self.connected.store(false, Ordering::Relaxed);
+        self.last_error.store(Arc::new(Some(err.to_string())));
+    }
+}
+
+fn unix_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn new_session_fields(connected: bool) -> (AtomicBool, ArcSwap<Option<String>>, AtomicU64) {
+    (
+        AtomicBool::new(connected),
+        ArcSwap::from_pointee(None),
+        AtomicU64::new(if connected { unix_ms_now() } else { 0 }),
+    )
 }
 
 impl UpstreamPool {
@@ -204,14 +240,17 @@ impl UpstreamPool {
             sidecar_spec: None,
             enabled: true,
         };
+        let (connected, last_error, last_ok_unix_ms) = new_session_fields(true);
         let sess = UpstreamSession {
-            spec,
+            spec: ArcSwap::from_pointee(spec),
             client: Mutex::new(None),
             tools: ArcSwap::from_pointee(vec![]),
             resolved: ArcSwap::from_pointee(tools),
             prompts: ArcSwap::from_pointee(vec![]),
             call_lock: Mutex::new(()),
-            connected: AtomicBool::new(true),
+            connected,
+            last_error,
+            last_ok_unix_ms,
         };
         self.sessions.insert(name, Arc::new(sess));
     }
@@ -238,14 +277,17 @@ impl UpstreamPool {
             sidecar_spec: None,
             enabled: true,
         };
+        let (connected, last_error, last_ok_unix_ms) = new_session_fields(true);
         let sess = UpstreamSession {
-            spec,
+            spec: ArcSwap::from_pointee(spec),
             client: Mutex::new(None),
             tools: ArcSwap::from_pointee(vec![]),
             resolved: ArcSwap::from_pointee(tools),
             prompts: ArcSwap::from_pointee(prompts),
             call_lock: Mutex::new(()),
-            connected: AtomicBool::new(true),
+            connected,
+            last_error,
+            last_ok_unix_ms,
         };
         self.sessions.insert(name, Arc::new(sess));
     }
@@ -256,7 +298,18 @@ impl UpstreamPool {
     pub fn description_of(&self, server: &str) -> Option<String> {
         self.sessions
             .get(server)
-            .and_then(|s| s.spec.description.clone())
+            .and_then(|s| s.spec.load().description.clone())
+    }
+
+    /// Update description without respawning (G15).
+    pub fn set_description(&self, server: &str, description: Option<String>) -> bool {
+        let Some(sess) = self.sessions.get(server) else {
+            return false;
+        };
+        let mut next = (**sess.spec.load()).clone();
+        next.description = description;
+        sess.spec.store(Arc::new(next));
+        true
     }
 
     /// Resolved tools for an upstream, or None if unknown.
@@ -329,17 +382,13 @@ impl UpstreamPool {
     }
 
     /// Call an upstream tool. Returns the rmcp `CallToolResult` or an error if
-    /// the upstream is gone / disconnected / timed out.
+    /// the upstream is gone / timed out. Updates per-session status on outcome.
     pub async fn call(&self, server: &str, tool: &str, args: Value) -> Result<CallToolResult> {
         let sess = self
             .sessions
             .get(server)
             .ok_or_else(|| anyhow!("unknown upstream: {server}"))?
             .clone();
-
-        if !sess.connected.load(Ordering::Relaxed) {
-            return Err(anyhow!("upstream '{server}' is disconnected"));
-        }
 
         let _guard = sess.call_lock.lock().await;
 
@@ -364,6 +413,7 @@ impl UpstreamPool {
                     let mut result = CallToolResult::default();
                     result.content = vec![rmcp::model::Content::text(msg)];
                     result.is_error = Some(true);
+                    // SQL guard is a local policy reject — not an upstream outage.
                     return Ok(result);
                 }
             }
@@ -378,15 +428,33 @@ impl UpstreamPool {
         };
 
         let client_guard = sess.client.lock().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or_else(|| anyhow!("upstream '{server}' has no client"))?;
+        let client = match client_guard.as_ref() {
+            Some(c) => c,
+            None => {
+                let msg = format!("upstream '{server}' has no client");
+                sess.mark_err(&msg);
+                return Err(anyhow!(msg));
+            }
+        };
 
-        let res = tokio::time::timeout(self.call_timeout, client.call_tool(req))
-            .await
-            .map_err(|_| anyhow!("upstream '{server}' tool '{tool}' call timed out"))?
-            .with_context(|| format!("upstream '{server}' tool '{tool}' call failed"))?;
-        Ok(res)
+        let res = tokio::time::timeout(self.call_timeout, client.call_tool(req)).await;
+        match res {
+            Ok(Ok(r)) => {
+                sess.mark_ok();
+                Ok(r)
+            }
+            Ok(Err(e)) => {
+                let err =
+                    anyhow!(e).context(format!("upstream '{server}' tool '{tool}' call failed"));
+                sess.mark_err(format!("{err:#}"));
+                Err(err)
+            }
+            Err(_) => {
+                let msg = format!("upstream '{server}' tool '{tool}' call timed out");
+                sess.mark_err(&msg);
+                Err(anyhow!(msg))
+            }
+        }
     }
 
     /// Fetch an upstream prompt via `prompts/get`. Arguments are forwarded
@@ -410,10 +478,6 @@ impl UpstreamPool {
             .ok_or_else(|| anyhow!("unknown upstream: {server}"))?
             .clone();
 
-        if !sess.connected.load(Ordering::Relaxed) {
-            return Err(anyhow!("upstream '{server}' is disconnected"));
-        }
-
         let _guard = sess.call_lock.lock().await;
 
         let req = GetPromptRequestParams::new(name.to_string());
@@ -423,15 +487,32 @@ impl UpstreamPool {
         };
 
         let client_guard = sess.client.lock().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or_else(|| anyhow!("upstream '{server}' has no client"))?;
+        let client = match client_guard.as_ref() {
+            Some(c) => c,
+            None => {
+                let msg = format!("upstream '{server}' has no client");
+                sess.mark_err(&msg);
+                return Err(anyhow!(msg));
+            }
+        };
 
-        let res = tokio::time::timeout(self.call_timeout, client.get_prompt(req))
-            .await
-            .map_err(|_| anyhow!("upstream '{server}' prompt '{name}' get timed out"))?
-            .with_context(|| format!("upstream '{server}' prompt '{name}' get failed"))?;
-        Ok(res)
+        match tokio::time::timeout(self.call_timeout, client.get_prompt(req)).await {
+            Ok(Ok(r)) => {
+                sess.mark_ok();
+                Ok(r)
+            }
+            Ok(Err(e)) => {
+                let err =
+                    anyhow!(e).context(format!("upstream '{server}' prompt '{name}' get failed"));
+                sess.mark_err(format!("{err:#}"));
+                Err(err)
+            }
+            Err(_) => {
+                let msg = format!("upstream '{server}' prompt '{name}' get timed out");
+                sess.mark_err(&msg);
+                Err(anyhow!(msg))
+            }
+        }
     }
 
     /// Re-fetch `prompts/list` for one upstream and swap the cached catalogue.
@@ -443,20 +524,30 @@ impl UpstreamPool {
             .ok_or_else(|| anyhow!("unknown upstream: {server}"))?
             .clone();
 
-        if !sess.connected.load(Ordering::Relaxed) {
-            return Err(anyhow!("upstream '{server}' is disconnected"));
-        }
-
         let _guard = sess.call_lock.lock().await;
         let client_guard = sess.client.lock().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or_else(|| anyhow!("upstream '{server}' has no client"))?;
+        let client = match client_guard.as_ref() {
+            Some(c) => c,
+            None => {
+                let msg = format!("upstream '{server}' has no client");
+                sess.mark_err(&msg);
+                return Err(anyhow!(msg));
+            }
+        };
 
-        let live = tokio::time::timeout(self.call_timeout, client.list_all_prompts())
-            .await
-            .map_err(|_| anyhow!("upstream '{server}' prompts/list timed out"))?
-            .with_context(|| format!("upstream '{server}' prompts/list failed"))?;
+        let live = match tokio::time::timeout(self.call_timeout, client.list_all_prompts()).await {
+            Ok(Ok(p)) => p,
+            Ok(Err(e)) => {
+                let err = anyhow!(e).context(format!("upstream '{server}' prompts/list failed"));
+                sess.mark_err(format!("{err:#}"));
+                return Err(err);
+            }
+            Err(_) => {
+                let msg = format!("upstream '{server}' prompts/list timed out");
+                sess.mark_err(&msg);
+                return Err(anyhow!(msg));
+            }
+        };
 
         let resolved = resolve_prompts(server, live);
         info!(
@@ -465,6 +556,7 @@ impl UpstreamPool {
             "refreshed upstream prompts cache"
         );
         sess.prompts.store(Arc::new(resolved));
+        sess.mark_ok();
         Ok(())
     }
 
@@ -485,6 +577,186 @@ impl UpstreamPool {
     pub fn bus(&self) -> Arc<Bus> {
         self.bus.clone()
     }
+
+    /// Snapshot of live sessions for operator status APIs.
+    pub fn status_snapshot(&self) -> Vec<UpstreamStatus> {
+        let mut out: Vec<_> = self
+            .sessions
+            .iter()
+            .map(|kv| {
+                let s = kv.value();
+                let last_ok = s.last_ok_unix_ms.load(Ordering::Relaxed);
+                let spec = s.spec.load();
+                UpstreamStatus {
+                    name: kv.key().clone(),
+                    description: spec.description.clone(),
+                    transport: format!("{:?}", spec.transport).to_ascii_lowercase(),
+                    connected: s.connected.load(Ordering::Relaxed),
+                    tool_count: s.resolved.load().len(),
+                    prompt_count: s.prompts.load().len(),
+                    last_error: s.last_error.load_full().as_ref().clone(),
+                    last_ok_unix_ms: (last_ok > 0).then_some(last_ok),
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out
+    }
+
+    /// Current registry specs held by live sessions (for reconcile diffs).
+    pub fn specs_snapshot(&self) -> Vec<UpstreamSpec> {
+        let mut out: Vec<_> = self
+            .sessions
+            .iter()
+            .map(|kv| (**kv.value().spec.load()).clone())
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out
+    }
+
+    /// Cancel and remove one upstream. Missing name is a no-op.
+    pub async fn remove(&self, name: &str) {
+        let Some((_, sess)) = self.sessions.remove(name) else {
+            return;
+        };
+        let mut guard = sess.client.lock().await;
+        if let Some(c) = guard.take() {
+            if let Err(e) = c.cancel().await {
+                warn!(upstream = %name, error = %e, "upstream cancel failed on remove");
+            }
+        }
+        sess.connected.store(false, Ordering::Relaxed);
+        info!(upstream = %name, "upstream removed from pool");
+    }
+
+    /// Insert or replace a live session (caller already spawned it).
+    pub async fn upsert(&self, name: String, sess: UpstreamSession) {
+        if self.sessions.contains_key(&name) {
+            self.remove(&name).await;
+        }
+        self.sessions.insert(name.clone(), Arc::new(sess));
+        info!(upstream = %name, "upstream upserted into pool");
+    }
+
+    /// Re-run `tools/list` + sidecar merge for one upstream (list_changed path).
+    pub async fn refresh_tools(
+        &self,
+        server: &str,
+        spec_dir: Option<&std::path::Path>,
+    ) -> Result<()> {
+        let sess = self
+            .sessions
+            .get(server)
+            .ok_or_else(|| anyhow!("unknown upstream: {server}"))?
+            .clone();
+        let _guard = sess.call_lock.lock().await;
+        let client_guard = sess.client.lock().await;
+        let client = match client_guard.as_ref() {
+            Some(c) => c,
+            None => {
+                let msg = format!("upstream '{server}' has no client");
+                sess.mark_err(&msg);
+                return Err(anyhow!(msg));
+            }
+        };
+
+        let live_tools =
+            match tokio::time::timeout(self.call_timeout, client.list_all_tools()).await {
+                Ok(Ok(t)) => t,
+                Ok(Err(e)) => {
+                    let err = anyhow!(e).context(format!("upstream '{server}' tools/list failed"));
+                    sess.mark_err(format!("{err:#}"));
+                    return Err(err);
+                }
+                Err(_) => {
+                    let msg = format!("upstream '{server}' tools/list timed out");
+                    sess.mark_err(&msg);
+                    return Err(anyhow!(msg));
+                }
+            };
+
+        let sidecar = resolve_sidecar(&sess.spec.load(), spec_dir)?;
+        let cached: Vec<CachedTool> = live_tools
+            .iter()
+            .map(|t| CachedTool {
+                name: t.name.to_string(),
+                description: t.description.as_ref().map(|s| s.to_string()),
+                input_schema: serde_json::to_value(&t.input_schema)
+                    .unwrap_or_else(|_| serde_json::json!({"type": "object"})),
+                read_only: tool_read_only_hint(t),
+                task_support: tool_task_support_hint(t),
+            })
+            .collect();
+        let (merged, _audit) = apply_sidecar(cached, sidecar.as_ref());
+        let resolved: Vec<ResolvedTool> = merged
+            .into_iter()
+            .map(|c| ResolvedTool {
+                server: server.to_string(),
+                name: c.name,
+                description: c.description,
+                input_schema: c.input_schema,
+                read_only: c.read_only,
+                task_support: c.task_support,
+            })
+            .collect();
+        info!(
+            upstream = %server,
+            count = resolved.len(),
+            "refreshed upstream tools cache"
+        );
+        sess.tools.store(Arc::new(live_tools));
+        sess.resolved.store(Arc::new(resolved));
+        sess.mark_ok();
+        Ok(())
+    }
+
+    /// Number of sessions currently marked connected.
+    pub fn connected_count(&self) -> usize {
+        self.sessions
+            .iter()
+            .filter(|kv| kv.value().connected.load(Ordering::Relaxed))
+            .count()
+    }
+
+    /// True if at least one session is connected.
+    ///
+    /// Note: an **empty** pool returns `false`. Callers that mean "no work to
+    /// do" (zero enabled upstreams in the registry) must check the registry
+    /// separately — see `/ready`.
+    pub fn any_connected(&self) -> bool {
+        self.connected_count() > 0
+    }
+
+    /// Spawn timeout used for reconcile add/replace.
+    pub fn call_timeout(&self) -> Duration {
+        self.call_timeout
+    }
+}
+
+/// Operator-facing upstream status row.
+#[derive(Debug, Clone)]
+pub struct UpstreamStatus {
+    pub name: String,
+    pub description: Option<String>,
+    pub transport: String,
+    pub connected: bool,
+    pub tool_count: usize,
+    pub prompt_count: usize,
+    pub last_error: Option<String>,
+    pub last_ok_unix_ms: Option<u64>,
+}
+
+/// Compare fields that require a session replace when they change.
+pub fn spec_requires_respawn(a: &UpstreamSpec, b: &UpstreamSpec) -> bool {
+    a.transport != b.transport
+        || a.url != b.url
+        || a.bearer != b.bearer
+        || a.command != b.command
+        || a.args != b.args
+        || a.env != b.env
+        || a.cwd != b.cwd
+        || a.sidecar_spec != b.sidecar_spec
+        || a.enabled != b.enabled
 }
 
 /// Spawn a single upstream. Public so tests can do one-shot spawns.
@@ -574,14 +846,17 @@ pub async fn spawn_one(
         })
         .collect();
 
+    let (connected, last_error, last_ok_unix_ms) = new_session_fields(true);
     Ok(UpstreamSession {
-        spec,
+        spec: ArcSwap::from_pointee(spec),
         client: Mutex::new(Some(client)),
         tools: ArcSwap::from_pointee(live_tools),
         resolved: ArcSwap::from_pointee(resolved),
         prompts: ArcSwap::from_pointee(resolved_prompts),
         call_lock: Mutex::new(()),
-        connected: AtomicBool::new(true),
+        connected,
+        last_error,
+        last_ok_unix_ms,
     })
 }
 
@@ -741,3 +1016,90 @@ pub fn build_lock_from_pool(pool: &UpstreamPool) -> ToolsLock {
 /// the common case of consuming this crate.
 pub use vmcp_notify as notify;
 pub use vmcp_registry as registry;
+
+#[cfg(test)]
+mod status_tests {
+    use super::*;
+    use vmcp_notify::Bus;
+
+    #[test]
+    fn empty_pool_has_zero_connected() {
+        let pool = UpstreamPool::empty_for_test(Bus::new(8));
+        assert_eq!(pool.connected_count(), 0);
+        assert!(!pool.any_connected());
+        assert!(pool.status_snapshot().is_empty());
+    }
+
+    #[test]
+    fn synthetic_session_reports_connected_and_tool_count() {
+        let pool = UpstreamPool::empty_for_test(Bus::new(8));
+        pool.insert_synthetic_for_test(
+            "alpha",
+            Some("desc".into()),
+            vec![ResolvedTool {
+                server: "alpha".into(),
+                name: "echo".into(),
+                description: None,
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: true,
+                task_support: vmcp_registry::TaskSupportHint::Forbidden,
+            }],
+        );
+        assert!(pool.any_connected());
+        let snap = pool.status_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].name, "alpha");
+        assert!(snap[0].connected);
+        assert_eq!(snap[0].tool_count, 1);
+        assert!(snap[0].last_error.is_none());
+        assert!(snap[0].last_ok_unix_ms.is_some());
+    }
+
+    #[test]
+    fn mark_err_then_mark_ok_updates_status() {
+        let pool = UpstreamPool::empty_for_test(Bus::new(8));
+        pool.insert_synthetic_for_test("s", None, vec![]);
+        let sess = pool.sessions.get("s").unwrap().clone();
+        sess.mark_err("boom");
+        let bad = pool.status_snapshot();
+        assert!(!bad[0].connected);
+        assert_eq!(bad[0].last_error.as_deref(), Some("boom"));
+        assert!(!pool.any_connected());
+
+        sess.mark_ok();
+        let good = pool.status_snapshot();
+        assert!(good[0].connected);
+        assert!(good[0].last_error.is_none());
+        assert!(pool.any_connected());
+    }
+
+    #[test]
+    fn set_description_updates_without_respawn() {
+        let pool = UpstreamPool::empty_for_test(Bus::new(8));
+        pool.insert_synthetic_for_test("s", Some("old".into()), vec![]);
+        assert!(pool.set_description("s", Some("new".into())));
+        assert_eq!(pool.description_of("s").as_deref(), Some("new"));
+        assert_eq!(pool.specs_snapshot()[0].description.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn spec_requires_respawn_on_url_change() {
+        let a = UpstreamSpec {
+            name: "x".into(),
+            description: None,
+            transport: vmcp_registry::UpstreamTransport::Http,
+            url: Some("http://a/mcp".into()),
+            bearer: None,
+            command: String::new(),
+            args: vec![],
+            env: Default::default(),
+            cwd: None,
+            sidecar_spec: None,
+            enabled: true,
+        };
+        let mut b = a.clone();
+        assert!(!spec_requires_respawn(&a, &b));
+        b.url = Some("http://b/mcp".into());
+        assert!(spec_requires_respawn(&a, &b));
+    }
+}

--- a/crates/vmcp-watch/src/lib.rs
+++ b/crates/vmcp-watch/src/lib.rs
@@ -25,6 +25,10 @@ use std::path::{Path, PathBuf};
 
 use notify::{recommended_watcher, Event, RecommendedWatcher, RecursiveMode, Watcher};
 
+/// Re-export so callers can name the watcher guard type without a direct
+/// `notify` dependency.
+pub use notify::RecommendedWatcher as FileWatcher;
+
 /// Start watching `path` for changes; invoke `cb` on every change that touches
 /// it. The returned [`RecommendedWatcher`] MUST be kept alive for as long as
 /// you want events — dropping it silently stops the watch. Bind it like
@@ -34,6 +38,28 @@ use notify::{recommended_watcher, Event, RecommendedWatcher, RecursiveMode, Watc
 /// are filtered to `path`'s file name, so it survives the tmp+rename atomic
 /// write pattern (see module docs).
 pub fn spawn_file_watcher<F>(path: &Path, cb: F) -> anyhow::Result<RecommendedWatcher>
+where
+    F: Fn() + Send + 'static,
+{
+    spawn_file_watcher_mode(path, RecursiveMode::NonRecursive, cb)
+}
+
+/// Like [`spawn_file_watcher`], but watches the parent tree recursively.
+///
+/// Useful for Kubernetes ConfigMap mounts where kubelet updates via a
+/// `..data` symlink dance that non-recursive watches often miss (G03).
+pub fn spawn_file_watcher_recursive<F>(path: &Path, cb: F) -> anyhow::Result<RecommendedWatcher>
+where
+    F: Fn() + Send + 'static,
+{
+    spawn_file_watcher_mode(path, RecursiveMode::Recursive, cb)
+}
+
+fn spawn_file_watcher_mode<F>(
+    path: &Path,
+    mode: RecursiveMode,
+    cb: F,
+) -> anyhow::Result<RecommendedWatcher>
 where
     F: Fn() + Send + 'static,
 {
@@ -51,10 +77,16 @@ where
     let filter_name = target_name.clone();
     let mut watcher = recommended_watcher(move |res: Result<Event, notify::Error>| match res {
         Ok(event) => {
-            let touches_target = event
-                .paths
-                .iter()
-                .any(|p| p.file_name() == Some(filter_name.as_os_str()));
+            // Match target file name OR kubelet `..data` / `..YYYY_…` symlink churn
+            // in the watched tree (ConfigMap projected volume).
+            let touches_target = event.paths.iter().any(|p| {
+                let name = p.file_name().map(|n| n.to_string_lossy());
+                match name.as_deref() {
+                    Some(n) if n == filter_name => true,
+                    Some(n) if n == "..data" || n.starts_with("..") => true,
+                    _ => false,
+                }
+            });
             if touches_target {
                 tracing::debug!(kind = ?event.kind, "watched file changed");
                 cb();
@@ -63,8 +95,13 @@ where
         Err(e) => tracing::warn!(error = %e, "file watcher error"),
     })?;
 
-    watcher.watch(&parent, RecursiveMode::NonRecursive)?;
-    tracing::info!(dir = %parent.display(), file = ?target_name, "file watcher started");
+    watcher.watch(&parent, mode)?;
+    tracing::info!(
+        dir = %parent.display(),
+        file = ?target_name,
+        recursive = matches!(mode, RecursiveMode::Recursive),
+        "file watcher started"
+    );
     Ok(watcher)
 }
 

--- a/crates/vmcp/Cargo.toml
+++ b/crates/vmcp/Cargo.toml
@@ -38,10 +38,10 @@ arc-swap = { workspace = true }
 url = { workspace = true }
 axum = { workspace = true }
 tower = { workspace = true }
-tower-http = { workspace = true }
 bytes = { version = "1" }
 futures = { workspace = true }
 async-stream = { version = "0.3" }
+sha2 = "0.10"
 
 [features]
 default = ["admin"]
@@ -72,4 +72,4 @@ async-graphql = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 axum = { workspace = true }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/crates/vmcp/src/api_v1.rs
+++ b/crates/vmcp/src/api_v1.rs
@@ -1,0 +1,321 @@
+//! Operator control-plane JSON API at `/api/v1`.
+//!
+//! Authenticated with Bearer + scope `mcp:admin` (not HTTP Basic — that stays
+//! on `/admin`). Token CRUD writes the same `tokens_file` format as
+//! `vmcp pre-reg`; the existing file watcher hot-reloads the in-memory store.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+use vmcp_auth::static_tokens::{
+    self, generate_entry, read_entries, revoke_by_client_id, rotate_by_client_id, RevokeOutcome,
+    SCOPE_ADMIN,
+};
+use vmcp_auth::AuthState;
+use vmcp_upstream::UpstreamPool;
+
+/// Shared state for `/api/v1` handlers.
+#[derive(Clone)]
+pub struct ApiV1State {
+    pub auth: AuthState,
+    pub tokens_file: Option<PathBuf>,
+    pub tokens_write_lock: Arc<Mutex<()>>,
+    /// Optional registry reconcile hook (Phase 2). `None` → upstreams reload 503.
+    pub reload_registry: Option<RegistryReloader>,
+    pub pool: Option<Arc<UpstreamPool>>,
+}
+
+/// Async callback that reconciles `registry.json` into the live pool/schema.
+pub type RegistryReloader = Arc<
+    dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<Value>> + Send>>
+        + Send
+        + Sync,
+>;
+
+impl ApiV1State {
+    pub fn new(auth: AuthState, tokens_file: Option<PathBuf>) -> Self {
+        Self {
+            auth,
+            tokens_file,
+            tokens_write_lock: Arc::new(Mutex::new(())),
+            reload_registry: None,
+            pool: None,
+        }
+    }
+
+    pub fn with_reload(mut self, reload: RegistryReloader) -> Self {
+        self.reload_registry = Some(reload);
+        self
+    }
+
+    pub fn with_pool(mut self, pool: Arc<UpstreamPool>) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+}
+
+/// Router nested at `/api/v1`. Caller must layer bearer + admin-scope middleware
+/// with `AuthState` (see `main::serve_http`).
+pub fn router(state: ApiV1State) -> Router {
+    Router::new()
+        .route("/tokens", get(list_tokens).post(create_token))
+        .route(
+            "/tokens/:client_id",
+            axum::routing::put(rotate_token).delete(delete_token),
+        )
+        .route("/upstreams", get(list_upstreams))
+        .route("/upstreams/reload", post(reload_upstreams))
+        .with_state(state)
+}
+
+async fn list_tokens(State(s): State<ApiV1State>) -> impl IntoResponse {
+    let path = match tokens_path(&s) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    match read_entries(&path) {
+        Ok(entries) => {
+            let items: Vec<Value> = entries
+                .iter()
+                .map(|e| serde_json::to_value(e.to_list_item()).unwrap_or(json!({})))
+                .collect();
+            (StatusCode::OK, Json(json!({ "tokens": items }))).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateTokenBody {
+    name: String,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+async fn create_token(
+    State(s): State<ApiV1State>,
+    Json(body): Json<CreateTokenBody>,
+) -> impl IntoResponse {
+    let path = match tokens_path(&s) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let _guard = s.tokens_write_lock.lock().await;
+
+    let existing = match read_entries(&path) {
+        Ok(e) => e,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    if existing.iter().any(|e| e.client_id == body.name) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": format!("client_id already exists: {}", body.name) })),
+        )
+            .into_response();
+    }
+
+    let entry = match generate_entry(&body.name, body.scope.as_deref()) {
+        Ok(e) => e,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    if let Err(e) = static_tokens::append_atomic(&path, &entry) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response();
+    }
+
+    // Best-effort: if a store is attached, reload immediately so the new token
+    // works even if the file watcher is slow/unavailable.
+    if let Some(store) = s.auth.token_store.as_ref() {
+        store.reload(&path);
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(json!({
+            "client_id": entry.client_id,
+            "name": entry.name,
+            "scope": entry.scope,
+            "issued_at": entry.issued_at,
+            "token": entry.token,
+        })),
+    )
+        .into_response()
+}
+
+async fn rotate_token(
+    State(s): State<ApiV1State>,
+    Path(client_id): Path<String>,
+) -> impl IntoResponse {
+    let path = match tokens_path(&s) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    if !static_tokens::valid_id(&client_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid client_id" })),
+        )
+            .into_response();
+    }
+    let _guard = s.tokens_write_lock.lock().await;
+    match rotate_by_client_id(&path, &client_id) {
+        Ok(Some(entry)) => {
+            if let Some(store) = s.auth.token_store.as_ref() {
+                store.reload(&path);
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "client_id": entry.client_id,
+                    "name": entry.name,
+                    "scope": entry.scope,
+                    "issued_at": entry.issued_at,
+                    "token": entry.token,
+                })),
+            )
+                .into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("unknown client_id: {client_id}") })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+async fn delete_token(
+    State(s): State<ApiV1State>,
+    Path(client_id): Path<String>,
+) -> impl IntoResponse {
+    let path = match tokens_path(&s) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    if !static_tokens::valid_id(&client_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid client_id" })),
+        )
+            .into_response();
+    }
+    let _guard = s.tokens_write_lock.lock().await;
+    match revoke_by_client_id(&path, &client_id) {
+        Ok(RevokeOutcome::Revoked) => {
+            if let Some(store) = s.auth.token_store.as_ref() {
+                store.reload(&path);
+            }
+            (StatusCode::NO_CONTENT, ()).into_response()
+        }
+        Ok(RevokeOutcome::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("unknown client_id: {client_id}") })),
+        )
+            .into_response(),
+        Ok(RevokeOutcome::LastAdmin) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "refusing to revoke last token with scope {SCOPE_ADMIN}"
+                )
+            })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+async fn list_upstreams(State(s): State<ApiV1State>) -> impl IntoResponse {
+    let Some(pool) = s.pool.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "upstream pool not available" })),
+        )
+            .into_response();
+    };
+    let upstreams: Vec<Value> = pool
+        .status_snapshot()
+        .into_iter()
+        .map(|u| {
+            json!({
+                "name": u.name,
+                "description": u.description,
+                "transport": u.transport,
+                "connected": u.connected,
+                "tool_count": u.tool_count,
+                "prompt_count": u.prompt_count,
+                "last_error": u.last_error,
+                "last_ok_unix_ms": u.last_ok_unix_ms,
+            })
+        })
+        .collect();
+    (StatusCode::OK, Json(json!({ "upstreams": upstreams }))).into_response()
+}
+
+async fn reload_upstreams(State(s): State<ApiV1State>) -> impl IntoResponse {
+    let Some(reload) = s.reload_registry.clone() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "registry reload not configured" })),
+        )
+            .into_response();
+    };
+    match reload().await {
+        Ok(report) => (StatusCode::OK, Json(report)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+fn tokens_path(s: &ApiV1State) -> Result<PathBuf, axum::response::Response> {
+    match &s.tokens_file {
+        Some(p) => Ok(p.clone()),
+        None => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "auth.tokens_file is not configured"
+            })),
+        )
+            .into_response()),
+    }
+}

--- a/crates/vmcp/src/boot.rs
+++ b/crates/vmcp/src/boot.rs
@@ -22,15 +22,12 @@ use vmcp_upstream::UpstreamPool;
 /// Everything the HTTP ingress needs after config is loaded.
 pub struct BootContext {
     pub cfg: Settings,
-    // `bus`, `schema_swap`, and `skills` are consumed only by the admin UI
-    // (feature `admin`); HTTP-without-admin still builds them for the MCP
-    // server surface but never reads the handles outside boot.
+    // `bus` is consumed by the admin UI (feature `admin`).
     #[cfg_attr(not(feature = "admin"), allow(dead_code))]
     pub bus: Arc<Bus>,
     pub pool: Arc<UpstreamPool>,
-    #[cfg_attr(not(feature = "admin"), allow(dead_code))]
+    /// Shared with MCP server + registry hot-reload (+ admin when enabled).
     pub schema_swap: SchemaHandle,
-    #[cfg_attr(not(feature = "admin"), allow(dead_code))]
     pub skills: SkillsHandle,
     pub vmcp_server: VmcpServer,
 }
@@ -84,33 +81,35 @@ pub async fn boot(cfg: Settings) -> Result<BootContext> {
     let schema_swap: SchemaHandle = Arc::new(ArcSwap::from_pointee(schema));
 
     // Native MCP Tasks (SEP-1686) — SQLite-backed `run_task` for task-capable
-    // upstream tools only (execution.taskSupport / sidecar task_support).
+    // upstream tools. Always create the runner when enabled (even with an empty
+    // allowlist) so a later registry hot-reload can populate tools without a
+    // process restart (Bugbot: empty registry disables tasks).
     let task_runner = if cfg.tasks.enabled {
         let allowlist = collect_task_allowlist(&pool);
         if allowlist.is_empty() {
             warn!(
-                "tasks.enabled but no upstream tools advertise taskSupport; \
-                 run_task will not be registered"
+                "tasks.enabled but no upstream tools advertise taskSupport yet; \
+                 TaskRunner is ready — allowlist will update on registry reload"
             );
-            None
         } else {
             info!(
                 db = %cfg.tasks.db_path.display(),
                 tools = allowlist.len(),
                 "native MCP tasks enabled (SQLite TaskStore)"
             );
-            Some(Arc::new(
-                TaskRunner::new(
-                    pool.clone(),
-                    cfg.tasks.db_path.clone(),
-                    allowlist,
-                    cfg.tasks.max_concurrent,
-                    cfg.tasks.task_ttl_ms,
-                    cfg.tasks.poll_interval_ms,
-                )
-                .context("open tasks sqlite db")?,
-            ))
         }
+        Some(Arc::new(
+            TaskRunner::new(
+                pool.clone(),
+                bus.clone(),
+                cfg.tasks.db_path.clone(),
+                allowlist,
+                cfg.tasks.max_concurrent,
+                cfg.tasks.task_ttl_ms,
+                cfg.tasks.poll_interval_ms,
+            )
+            .context("open tasks sqlite db")?,
+        ))
     } else {
         None
     };
@@ -122,9 +121,8 @@ pub async fn boot(cfg: Settings) -> Result<BootContext> {
         task_runner,
     );
 
-    // Push upstream MCP events to connected clients (pull stays available via
-    // `query_graphql { notifications }`).
-    vmcp_server.spawn_notification_forwarder();
+    // Notification forwarder is started from `serve_http` after
+    // `RegistryReloadHandle` exists, so `tools/list_changed` can rebuild schema.
 
     Ok(BootContext {
         cfg,

--- a/crates/vmcp/src/main.rs
+++ b/crates/vmcp/src/main.rs
@@ -8,11 +8,13 @@
 
 #![allow(clippy::result_large_err)]
 
+mod api_v1;
 mod boot;
 #[cfg(not(feature = "otel"))]
 mod mcp_capture;
 #[cfg(feature = "otel")]
 mod mcp_otel;
+mod registry_reload;
 
 use std::path::PathBuf;
 
@@ -153,11 +155,18 @@ async fn serve_http(
     };
     use tracing::{error, warn};
     use vmcp_auth::{
-        build_router as auth_router, client_store::ClientStore, jwks::JwksManager, require_bearer,
-        state::AuthState,
+        build_router as auth_router,
+        client_store::ClientStore,
+        jwks::JwksManager,
+        require_admin_scope, require_bearer,
+        state::{AuthState, DcrPolicy},
     };
     use vmcp_server::ProxyServer;
+    use vmcp_upstream::UpstreamPool;
     use vmcp_watch::spawn_file_watcher;
+
+    use crate::api_v1::{self, ApiV1State};
+    use crate::registry_reload::{spawn_registry_watcher, RegistryReloadHandle};
 
     let cfg = &ctx.cfg;
     info!(host = %cfg.host, port = cfg.port, "vmcp starting");
@@ -170,14 +179,16 @@ async fn serve_http(
 
     let vmcp_server = ctx.vmcp_server.clone();
     let pool = ctx.pool.clone();
+    let skills = ctx.skills.clone();
     #[cfg(feature = "admin")]
     let schema_swap = ctx.schema_swap.clone();
     #[cfg(feature = "admin")]
-    let skills = ctx.skills.clone();
-    #[cfg(feature = "admin")]
     let bus = ctx.bus.clone();
 
-    let jwks = JwksManager::new_with_fresh(&cfg.auth.jwt_kid)?;
+    let jwks = JwksManager::open(
+        &cfg.auth.jwt_kid,
+        cfg.auth.jwks_private_key_pem_path.as_deref(),
+    )?;
     let _rotation = if cfg.auth.enabled {
         Some(jwks.clone().spawn_rotation_task(
             Duration::from_secs(cfg.auth.jwks_rotate_secs),
@@ -199,7 +210,12 @@ async fn serve_http(
         resource_audience,
         cfg.auth.token_ttl_secs,
         cfg.auth.master_password_argon2.clone(),
-    );
+    )
+    .with_dcr_policy(DcrPolicy {
+        enabled: cfg.auth.dcr_enabled,
+        max_clients: cfg.auth.dcr_max_clients,
+        redirect_uri_allowlist: cfg.auth.dcr_redirect_uri_allowlist.clone(),
+    });
     if cfg.proxy.enabled {
         auth_state =
             auth_state.with_extra_resource_audiences(vec![format!("{base}{}", cfg.proxy.mcp_path)]);
@@ -283,8 +299,9 @@ async fn serve_http(
     }
     let rmcp_config =
         StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts.clone());
+    let vmcp_server_for_mcp = vmcp_server.clone();
     let rmcp_service = StreamableHttpService::new(
-        move || Ok(vmcp_server.clone()),
+        move || Ok(vmcp_server_for_mcp.clone()),
         LocalSessionManager::default().into(),
         rmcp_config,
     );
@@ -319,10 +336,106 @@ async fn serve_http(
         ));
     }
 
+    #[derive(Clone)]
+    struct ReadyState {
+        pool: Arc<UpstreamPool>,
+        registry_path: PathBuf,
+    }
+
+    async fn ready_handler(
+        axum::extract::State(st): axum::extract::State<ReadyState>,
+    ) -> impl axum::response::IntoResponse {
+        use axum::http::StatusCode;
+        use vmcp_registry::load_registry;
+
+        let enabled = match load_registry(&st.registry_path) {
+            Ok(reg) => reg.upstreams.iter().filter(|u| u.enabled).count(),
+            Err(_) => {
+                // Unreadable registry → not ready for traffic that needs upstreams.
+                return (StatusCode::SERVICE_UNAVAILABLE, "registry unreadable");
+            }
+        };
+        // Soft readiness: OK when nothing is expected, or ≥1 live session.
+        // Empty pool with enabled>0 (all spawns failed) must be 503 — do NOT
+        // treat "no sessions" as ready.
+        if enabled == 0 || st.pool.connected_count() > 0 {
+            (StatusCode::OK, "ready")
+        } else {
+            (StatusCode::SERVICE_UNAVAILABLE, "no upstreams connected")
+        }
+    }
+
+    let ready_state = ReadyState {
+        pool: pool.clone(),
+        registry_path: cfg.registry_path.clone(),
+    };
+
     let mut app = Router::new()
         .merge(auth_router(auth_state.clone()))
         .route("/health", get(|| async { "ok" }))
+        .route("/ready", get(ready_handler).with_state(ready_state))
         .nest(&cfg.mcp_path, mcp_router);
+
+    // Registry hot-reload (file watcher + /api/v1/upstreams/reload).
+    let reload_handle = RegistryReloadHandle::new(
+        ctx.cfg.clone(),
+        pool.clone(),
+        skills.clone(),
+        vmcp_server.clone(),
+    );
+
+    // Forward upstream MCP notifications; on tools/list_changed refresh cache + schema.
+    {
+        let reload = reload_handle.clone();
+        let hook: vmcp_server::ToolsChangedHook = std::sync::Arc::new(move |source: String| {
+            let reload = reload.clone();
+            Box::pin(async move {
+                reload.handle_tools_changed(&source).await;
+            })
+        });
+        vmcp_server.spawn_notification_forwarder_with_tools_hook(Some(hook));
+    }
+    let _registry_watcher = {
+        let parent_ok = cfg
+            .registry_path
+            .parent()
+            .map(|p| p.as_os_str().is_empty() || p.exists())
+            .unwrap_or(true);
+        if parent_ok {
+            match spawn_registry_watcher(reload_handle.clone(), cfg.registry_path.clone()) {
+                Ok(w) => Some(w),
+                Err(e) => {
+                    error!(error = %e, "failed to start registry watcher; hot-reload disabled");
+                    None
+                }
+            }
+        } else {
+            error!(
+                path = %cfg.registry_path.display(),
+                "registry file's parent dir is missing; hot-reload disabled"
+            );
+            None
+        }
+    };
+
+    // Operator control-plane (Bearer + mcp:admin). Parallel to `/admin` Basic SPA.
+    if cfg.auth.enabled {
+        let reload = reload_handle.clone();
+        let pool_status = reload_handle.pool();
+        let api_state = ApiV1State::new(auth_state.clone(), cfg.auth.tokens_file.clone())
+            .with_reload(std::sync::Arc::new(move || {
+                let reload = reload.clone();
+                Box::pin(async move { reload.reload().await })
+            }))
+            .with_pool(pool_status);
+        let api_router = api_v1::router(api_state)
+            .layer(middleware::from_fn(require_admin_scope))
+            .layer(middleware::from_fn_with_state(
+                auth_state.clone(),
+                require_bearer,
+            ));
+        app = app.nest("/api/v1", api_router);
+    }
 
     #[cfg(feature = "admin")]
     {

--- a/crates/vmcp/src/main.rs
+++ b/crates/vmcp/src/main.rs
@@ -355,10 +355,23 @@ async fn serve_http(
                 return (StatusCode::SERVICE_UNAVAILABLE, "registry unreadable");
             }
         };
-        // Soft readiness: OK when nothing is expected, or ≥1 live session.
-        // Empty pool with enabled>0 (all spawns failed) must be 503 — do NOT
-        // treat "no sessions" as ready.
-        if enabled == 0 || st.pool.connected_count() > 0 {
+        // Soft readiness:
+        // - enabled==0 and pool empty → ready (idle gateway)
+        // - enabled==0 but pool still has sessions → 503 (stale, await reconcile)
+        // - enabled>0 and ≥1 connected → ready
+        // - enabled>0 and 0 connected → 503 (spawn failures / all down)
+        let live = st.pool.names().len();
+        let connected = st.pool.connected_count();
+        if enabled == 0 {
+            if live == 0 {
+                (StatusCode::OK, "ready")
+            } else {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "stale upstreams still in pool",
+                )
+            }
+        } else if connected > 0 {
             (StatusCode::OK, "ready")
         } else {
             (StatusCode::SERVICE_UNAVAILABLE, "no upstreams connected")
@@ -389,9 +402,7 @@ async fn serve_http(
         let reload = reload_handle.clone();
         let hook: vmcp_server::ToolsChangedHook = std::sync::Arc::new(move |source: String| {
             let reload = reload.clone();
-            Box::pin(async move {
-                reload.handle_tools_changed(&source).await;
-            })
+            Box::pin(async move { reload.handle_tools_changed(&source).await })
         });
         vmcp_server.spawn_notification_forwarder_with_tools_hook(Some(hook));
     }

--- a/crates/vmcp/src/registry_reload.rs
+++ b/crates/vmcp/src/registry_reload.rs
@@ -58,8 +58,14 @@ impl RegistryReloadHandle {
     }
 
     /// Upstream `tools/list_changed`: refresh that server's tool cache and rebuild schema.
-    pub async fn handle_tools_changed(&self, source: &str) {
+    /// Returns `true` only when cache + schema (+ allowlist) are consistent, so
+    /// callers can skip notifying MCP clients on failure.
+    pub async fn handle_tools_changed(&self, source: &str) -> bool {
         let _guard = self.inner.lock.lock().await;
+        let Some((old_tools, old_resolved)) = self.inner.pool.tools_snapshot(source) else {
+            warn!(upstream = %source, "tools/list_changed for unknown upstream");
+            return false;
+        };
         if let Err(e) = self
             .inner
             .pool
@@ -71,21 +77,26 @@ impl RegistryReloadHandle {
                 error = %e,
                 "failed to refresh tools after list_changed"
             );
-            return;
+            return false;
         }
         if let Err(e) = rebuild_graphql_schema(&self.inner).await {
             warn!(
                 upstream = %source,
                 error = %e,
-                "failed to rebuild schema after tools/list_changed"
+                "failed to rebuild schema after tools/list_changed; rolling back tool cache"
             );
-            return;
+            let _ = self
+                .inner
+                .pool
+                .restore_tools(source, old_tools, old_resolved);
+            return false;
         }
         // Keep run_task allowlist in sync with sidecar-/list-merged taskSupport.
         if let Some(runner) = self.inner.vmcp_server.task_runner() {
             runner.replace_allowlist(vmcp_server::collect_task_allowlist(&self.inner.pool));
         }
         info!(upstream = %source, "tools/list_changed applied (cache + schema)");
+        true
     }
 }
 

--- a/crates/vmcp/src/registry_reload.rs
+++ b/crates/vmcp/src/registry_reload.rs
@@ -1,0 +1,358 @@
+//! Hot-reload / reconcile of `registry.json` into the live upstream pool + GraphQL schema.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+use tracing::{error, info, warn};
+use vmcp_config::{CapMode, Settings};
+use vmcp_graphql::{build_schema_with_prompts, CapMode as GqlCapMode, SchemaLimits};
+use vmcp_registry::{load_registry, save_lock_atomic, ToolsLock, UpstreamSpec};
+use vmcp_server::{prompt_source_handlers, SkillsHandle, VmcpServer};
+use vmcp_upstream::{spawn_one, spec_requires_respawn, UpstreamPool};
+
+/// Shared handle used by the file watcher and `POST /api/v1/upstreams/reload`.
+#[derive(Clone)]
+pub struct RegistryReloadHandle {
+    inner: Arc<RegistryReloadInner>,
+}
+
+pub(crate) struct RegistryReloadInner {
+    lock: Mutex<()>,
+    cfg: Settings,
+    pool: Arc<UpstreamPool>,
+    skills: SkillsHandle,
+    vmcp_server: VmcpServer,
+}
+
+impl RegistryReloadHandle {
+    pub fn new(
+        cfg: Settings,
+        pool: Arc<UpstreamPool>,
+        skills: SkillsHandle,
+        vmcp_server: VmcpServer,
+    ) -> Self {
+        Self {
+            inner: Arc::new(RegistryReloadInner {
+                lock: Mutex::new(()),
+                cfg,
+                pool,
+                skills,
+                vmcp_server,
+            }),
+        }
+    }
+
+    pub fn pool(&self) -> Arc<UpstreamPool> {
+        self.inner.pool.clone()
+    }
+
+    /// Reconcile disk registry with the live pool and rebuild the GraphQL schema.
+    pub async fn reload(&self) -> Result<Value> {
+        let _guard = self.inner.lock.lock().await;
+        reconcile(&self.inner).await
+    }
+
+    /// Upstream `tools/list_changed`: refresh that server's tool cache and rebuild schema.
+    pub async fn handle_tools_changed(&self, source: &str) {
+        let _guard = self.inner.lock.lock().await;
+        if let Err(e) = self
+            .inner
+            .pool
+            .refresh_tools(source, Some(self.inner.cfg.spec_dir.as_path()))
+            .await
+        {
+            warn!(
+                upstream = %source,
+                error = %e,
+                "failed to refresh tools after list_changed"
+            );
+            return;
+        }
+        if let Err(e) = rebuild_graphql_schema(&self.inner).await {
+            warn!(
+                upstream = %source,
+                error = %e,
+                "failed to rebuild schema after tools/list_changed"
+            );
+            return;
+        }
+        // Keep run_task allowlist in sync with sidecar-/list-merged taskSupport.
+        if let Some(runner) = self.inner.vmcp_server.task_runner() {
+            runner.replace_allowlist(vmcp_server::collect_task_allowlist(&self.inner.pool));
+        }
+        info!(upstream = %source, "tools/list_changed applied (cache + schema)");
+    }
+}
+
+/// Rebuild GraphQL schema from the live pool into the shared ArcSwap.
+pub(crate) async fn rebuild_graphql_schema(inner: &RegistryReloadInner) -> Result<()> {
+    let prompt_handlers = prompt_source_handlers(
+        inner.skills.clone(),
+        inner.pool.clone(),
+        inner.cfg.proxy.enabled,
+    );
+    let entries = inner.pool.all_resolved();
+    let schema = build_schema_with_prompts(
+        entries,
+        inner.pool.clone(),
+        SchemaLimits {
+            max_depth: inner.cfg.gql.max_depth,
+            max_complexity: inner.cfg.gql.max_complexity,
+            max_response_bytes: inner.cfg.gql.max_response_bytes,
+            response_cap_mode: match inner.cfg.gql.response_cap_mode {
+                CapMode::Error => GqlCapMode::Error,
+                CapMode::Truncate => GqlCapMode::Truncate,
+            },
+        },
+        Some(prompt_handlers),
+    )
+    .map_err(|e| anyhow::anyhow!("rebuild schema: {e}"))?;
+    inner.vmcp_server.swap_schema(schema);
+    Ok(())
+}
+
+async fn reconcile(inner: &RegistryReloadInner) -> Result<Value> {
+    let registry = load_registry(&inner.cfg.registry_path)
+        .with_context(|| format!("load registry {}", inner.cfg.registry_path.display()))?;
+
+    let desired: HashMap<String, UpstreamSpec> = registry
+        .upstreams
+        .into_iter()
+        .filter(|s| s.enabled)
+        .map(|s| (s.name.clone(), s))
+        .collect();
+
+    let current_specs = inner.pool.specs_snapshot();
+    let current_names: HashSet<String> = current_specs.iter().map(|s| s.name.clone()).collect();
+    let current_by_name: HashMap<String, UpstreamSpec> = current_specs
+        .into_iter()
+        .map(|s| (s.name.clone(), s))
+        .collect();
+
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut replaced = Vec::new();
+    let mut failed: Vec<Value> = Vec::new();
+
+    // Removals (or disabled).
+    for name in current_names.difference(&desired.keys().cloned().collect::<HashSet<_>>()) {
+        inner.pool.remove(name).await;
+        removed.push(name.clone());
+    }
+
+    let spawn_timeout = Duration::from_millis(inner.cfg.upstream.spawn_timeout_ms);
+    let spec_dir = Some(inner.cfg.spec_dir.as_path());
+
+    for (name, spec) in &desired {
+        match current_by_name.get(name) {
+            None => match spawn_with_timeout(spec.clone(), inner, spawn_timeout, spec_dir).await {
+                Ok(sess) => {
+                    inner.pool.upsert(name.clone(), sess).await;
+                    added.push(name.clone());
+                }
+                Err(e) => {
+                    error!(upstream = %name, error = %e, "registry reload: add failed");
+                    failed.push(json!({ "name": name, "error": e.to_string(), "op": "add" }));
+                }
+            },
+            Some(old) if spec_requires_respawn(old, spec) => {
+                match spawn_with_timeout(spec.clone(), inner, spawn_timeout, spec_dir).await {
+                    Ok(sess) => {
+                        inner.pool.upsert(name.clone(), sess).await;
+                        replaced.push(name.clone());
+                    }
+                    Err(e) => {
+                        error!(upstream = %name, error = %e, "registry reload: replace failed");
+                        failed.push(json!({
+                            "name": name,
+                            "error": e.to_string(),
+                            "op": "replace"
+                        }));
+                    }
+                }
+            }
+            Some(old) if old.description != spec.description => {
+                // G15: description-only — no cancel/spawn.
+                let _ = inner.pool.set_description(name, spec.description.clone());
+            }
+            Some(_) => {}
+        }
+    }
+
+    // Rebuild GraphQL schema from the new pool snapshot.
+    // Note: pool mutations above are already applied. If schema rebuild fails,
+    // return Err so the operator retries; pool stays at the new desired state
+    // (full transactional rollback of live sessions is not supported).
+    rebuild_graphql_schema(inner)
+        .await
+        .context("rebuild schema after registry reload")?;
+
+    // Keep run_task allowlist in sync after successful schema rebuild.
+    if let Some(runner) = inner.vmcp_server.task_runner() {
+        let allow = vmcp_server::collect_task_allowlist(&inner.pool);
+        info!(
+            tools = allow.len(),
+            "updated run_task allowlist after reload"
+        );
+        runner.replace_allowlist(allow);
+    }
+
+    let lock = ToolsLock::new(inner.pool.snapshot_lock());
+    if let Err(e) = save_lock_atomic(&inner.cfg.lock_path, &lock) {
+        warn!(error = %e, "failed to rewrite tools.lock.json after reload");
+    }
+
+    // Notify MCP clients that tools changed.
+    inner.pool.bus().publish(
+        "vmcp",
+        "notifications/tools/list_changed",
+        json!({ "reason": "registry_reload" }),
+    );
+
+    let statuses: Vec<Value> = inner
+        .pool
+        .status_snapshot()
+        .into_iter()
+        .map(|s| {
+            json!({
+                "name": s.name,
+                "description": s.description,
+                "transport": s.transport,
+                "connected": s.connected,
+                "tool_count": s.tool_count,
+                "prompt_count": s.prompt_count,
+                "last_error": s.last_error,
+            })
+        })
+        .collect();
+
+    let tool_count: usize = statuses
+        .iter()
+        .map(|s| s["tool_count"].as_u64().unwrap_or(0) as usize)
+        .sum();
+
+    info!(
+        added = added.len(),
+        removed = removed.len(),
+        replaced = replaced.len(),
+        failed = failed.len(),
+        tool_count,
+        "registry reconcile complete"
+    );
+
+    let (registry_sha256, mtime_unix_ms) = registry_file_meta(&inner.cfg.registry_path);
+
+    Ok(json!({
+        "added": added,
+        "removed": removed,
+        "replaced": replaced,
+        "failed": failed,
+        "tool_count": tool_count,
+        "upstreams": statuses,
+        "registry_sha256": registry_sha256,
+        "mtime_unix_ms": mtime_unix_ms,
+    }))
+}
+
+fn registry_file_meta(path: &std::path::Path) -> (Option<String>, Option<u64>) {
+    use sha2::{Digest, Sha256};
+    let meta = std::fs::metadata(path).ok();
+    let mtime = meta.and_then(|m| m.modified().ok()).and_then(|t| {
+        t.duration_since(std::time::UNIX_EPOCH)
+            .ok()
+            .map(|d| d.as_millis() as u64)
+    });
+    let sha = std::fs::read(path).ok().map(|bytes| {
+        let digest = Sha256::digest(&bytes);
+        format!("{digest:x}")
+    });
+    (sha, mtime)
+}
+
+async fn spawn_with_timeout(
+    spec: UpstreamSpec,
+    inner: &RegistryReloadInner,
+    spawn_timeout: Duration,
+    spec_dir: Option<&std::path::Path>,
+) -> Result<vmcp_upstream::UpstreamSession> {
+    let bus = inner.pool.bus();
+    let name = spec.name.clone();
+    match tokio::time::timeout(spawn_timeout, spawn_one(spec, bus, spec_dir)).await {
+        Ok(Ok(sess)) => Ok(sess),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(anyhow::anyhow!("spawn timed out for upstream {name}")),
+    }
+}
+
+/// Guards that must stay alive for registry hot-reload (inotify + mtime poll).
+#[allow(dead_code)] // fields exist to keep watcher/poller running
+pub struct RegistryWatchGuards {
+    pub watcher: vmcp_watch::FileWatcher,
+    pub poller: tokio::task::JoinHandle<()>,
+}
+
+/// Spawn a debounced file watcher + mtime poller that reloads the registry on
+/// change. Recursive watch + 2s mtime poll cover Kubernetes ConfigMap
+/// `..data` symlink updates (G03). Prefer `POST /api/v1/upstreams/reload`
+/// after operator applies a CM for deterministic reconcile.
+pub fn spawn_registry_watcher(
+    handle: RegistryReloadHandle,
+    registry_path: PathBuf,
+) -> anyhow::Result<RegistryWatchGuards> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc as StdArc;
+
+    let pending = StdArc::new(AtomicBool::new(false));
+    let pending_flag = pending.clone();
+    let handle_bg = handle.clone();
+
+    // Debounce worker: when flag is set, wait 300ms then reload once.
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if pending_flag.swap(false, Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                // Collapse bursts during the debounce window.
+                pending_flag.store(false, Ordering::SeqCst);
+                if let Err(e) = handle_bg.reload().await {
+                    error!(error = %e, "registry hot-reload failed");
+                }
+            }
+        }
+    });
+
+    let pending_cb = pending.clone();
+    let watcher = vmcp_watch::spawn_file_watcher_recursive(&registry_path, move || {
+        pending_cb.store(true, Ordering::SeqCst);
+    })?;
+
+    let pending_poll = pending.clone();
+    let poll_path = registry_path;
+    let poller = tokio::spawn(async move {
+        let mut last = std::fs::metadata(&poll_path)
+            .and_then(|m| m.modified())
+            .ok();
+        let mut tick = tokio::time::interval(Duration::from_secs(2));
+        loop {
+            tick.tick().await;
+            let now = std::fs::metadata(&poll_path)
+                .and_then(|m| m.modified())
+                .ok();
+            if now != last {
+                last = now;
+                tracing::debug!(
+                    path = %poll_path.display(),
+                    "registry mtime poll detected change"
+                );
+                pending_poll.store(true, Ordering::SeqCst);
+            }
+        }
+    });
+
+    Ok(RegistryWatchGuards { watcher, poller })
+}

--- a/crates/vmcp/tests/api_v1_tokens.rs
+++ b/crates/vmcp/tests/api_v1_tokens.rs
@@ -1,0 +1,172 @@
+//! Operator `/api/v1/tokens` e2e: Bearer + mcp:admin CRUD.
+
+mod common;
+
+use vmcp_auth::static_tokens::{append_atomic, generate_entry, SCOPE_ADMIN};
+
+const DEMO_ARGON2: &str = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8";
+
+fn write_auth_config(dir: &std::path::Path, tokens_file: &std::path::Path) -> std::path::PathBuf {
+    std::fs::write(dir.join("registry.json"), br#"{"upstreams":[]}"#).unwrap();
+    std::fs::create_dir_all(dir.join("state")).unwrap();
+    std::fs::create_dir_all(dir.join("specs")).unwrap();
+    std::fs::create_dir_all(dir.join("skills")).unwrap();
+
+    let config_path = dir.join("vmcp.toml");
+    let config = format!(
+        r#"
+host = "127.0.0.1"
+public_base_url = "http://127.0.0.1:8765"
+registry_path = "{reg}"
+lock_path     = "{lock}"
+spec_dir      = "{spec}"
+skills_dir    = "{skills}"
+
+[gql]
+max_depth = 10
+max_complexity = 1000
+
+[upstream]
+spawn_timeout_ms = 30000
+call_timeout_ms  = 60000
+
+[auth]
+enabled = true
+master_password_argon2 = "{argon}"
+jwt_kid = "test"
+jwks_rotate_secs = 86400
+token_ttl_secs = 3600
+tokens_file = "{tokens}"
+clients_db_path = "{clients}"
+"#,
+        reg = dir.join("registry.json").display(),
+        lock = dir.join("tools.lock.json").display(),
+        spec = dir.join("specs").display(),
+        skills = dir.join("skills").display(),
+        argon = DEMO_ARGON2,
+        tokens = tokens_file.display(),
+        clients = dir.join("state").join("clients.db").display(),
+    );
+    std::fs::write(&config_path, config).unwrap();
+    config_path
+}
+
+#[tokio::test]
+async fn api_v1_tokens_crud_and_scope_gate() {
+    let dir = common::TempDir::new("vmcp-api-v1-tokens");
+    let tokens = dir.path().join("tokens.json");
+    let admin = generate_entry("operator", Some(SCOPE_ADMIN)).unwrap();
+    let agent_pre = generate_entry("agent-pre", Some("mcp:use")).unwrap();
+    append_atomic(&tokens, &admin).unwrap();
+    append_atomic(&tokens, &agent_pre).unwrap();
+    let cfg = write_auth_config(dir.path(), &tokens);
+    let gw = common::spawn_gateway_auth(&cfg).await;
+    let base = format!("http://127.0.0.1:{}/api/v1/tokens", gw.port);
+    let client = reqwest::Client::new();
+
+    // No bearer → 401
+    let resp = client.get(&base).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // mcp:use → 403
+    let resp = client
+        .get(&base)
+        .header("Authorization", format!("Bearer {}", agent_pre.token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+
+    // mcp:admin → list (redacted)
+    let resp = client
+        .get(&base)
+        .header("Authorization", format!("Bearer {}", admin.token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let list = body["tokens"].as_array().expect("tokens array");
+    assert!(list.len() >= 2);
+    assert!(list.iter().all(|t| t.get("token").is_none()));
+    assert!(list.iter().any(|t| t["client_id"] == "operator"));
+
+    // Create agent token
+    let resp = client
+        .post(&base)
+        .header("Authorization", format!("Bearer {}", admin.token))
+        .json(&serde_json::json!({"name":"agent-a","scope":"mcp:use"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    let created: serde_json::Value = resp.json().await.unwrap();
+    let new_token = created["token"].as_str().expect("token once");
+    assert!(new_token.starts_with("vmcp_"));
+
+    // Duplicate → 409
+    let resp = client
+        .post(&base)
+        .header("Authorization", format!("Bearer {}", admin.token))
+        .json(&serde_json::json!({"name":"agent-a"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CONFLICT);
+
+    // New token works on /mcp
+    let mcp =
+        common::connect_client_with_token(NullClient, gw.mcp_url.clone(), Some(new_token)).await;
+    let tools = mcp.list_all_tools().await.expect("tools/list");
+    assert!(tools.iter().any(|t| t.name == "query_graphql"));
+    mcp.cancel().await.ok();
+
+    // Revoke agent-a
+    let resp = client
+        .delete(format!("{base}/agent-a"))
+        .header("Authorization", format!("Bearer {}", admin.token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NO_CONTENT);
+
+    // Revoked token rejected
+    let resp = reqwest::Client::new()
+        .post(&gw.mcp_url)
+        .header("Authorization", format!("Bearer {new_token}"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // Cannot revoke last admin
+    let resp = client
+        .delete(format!("{base}/agent-pre"))
+        .header("Authorization", format!("Bearer {}", admin.token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NO_CONTENT);
+    let resp = client
+        .delete(format!("{base}/operator"))
+        .header("Authorization", format!("Bearer {}", admin.token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
+#[derive(Clone, Default)]
+struct NullClient;
+
+impl rmcp::ClientHandler for NullClient {
+    fn get_info(&self) -> rmcp::model::ClientInfo {
+        rmcp::model::ClientInfo::new(
+            rmcp::model::ClientCapabilities::default(),
+            rmcp::model::Implementation::new("api-v1-test", "0.0.0"),
+        )
+    }
+}

--- a/crates/vmcp/tests/ready.rs
+++ b/crates/vmcp/tests/ready.rs
@@ -1,0 +1,88 @@
+//! `/ready` soft readiness: 503 when registry has enabled upstreams but none connected.
+
+mod common;
+
+use std::time::Duration;
+
+const DEMO_ARGON2: &str = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8";
+
+fn write_cfg(dir: &std::path::Path, registry: &str) -> std::path::PathBuf {
+    std::fs::write(dir.join("registry.json"), registry.as_bytes()).unwrap();
+    std::fs::create_dir_all(dir.join("state")).unwrap();
+    std::fs::create_dir_all(dir.join("specs")).unwrap();
+    std::fs::create_dir_all(dir.join("skills")).unwrap();
+    let tokens = dir.join("tokens.json");
+    std::fs::write(&tokens, b"[]").unwrap();
+
+    let config_path = dir.join("vmcp.toml");
+    let config = format!(
+        r#"
+host = "127.0.0.1"
+public_base_url = "http://127.0.0.1:8765"
+registry_path = "{reg}"
+lock_path     = "{lock}"
+spec_dir      = "{spec}"
+skills_dir    = "{skills}"
+
+[gql]
+max_depth = 10
+max_complexity = 1000
+
+[upstream]
+spawn_timeout_ms = 2000
+call_timeout_ms  = 2000
+
+[auth]
+enabled = false
+master_password_argon2 = "{argon}"
+"#,
+        reg = dir.join("registry.json").display(),
+        lock = dir.join("tools.lock.json").display(),
+        spec = dir.join("specs").display(),
+        skills = dir.join("skills").display(),
+        argon = DEMO_ARGON2,
+    );
+    std::fs::write(&config_path, config).unwrap();
+    config_path
+}
+
+#[tokio::test]
+async fn ready_ok_when_registry_empty() {
+    let dir = common::TempDir::new("vmcp-ready-empty");
+    let cfg = write_cfg(dir.path(), r#"{"upstreams":[]}"#);
+    let gw = common::spawn_gateway(&cfg).await;
+    let url = format!("http://127.0.0.1:{}/ready", gw.port);
+    let resp = reqwest::get(&url).await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(resp.text().await.unwrap().trim(), "ready");
+}
+
+#[tokio::test]
+async fn ready_503_when_all_enabled_upstreams_fail_to_spawn() {
+    let dir = common::TempDir::new("vmcp-ready-fail");
+    // HTTP upstream pointing at a closed port — spawn/handshake fails → empty pool.
+    let registry = r#"{
+      "upstreams": [
+        {
+          "name": "dead",
+          "transport": "http",
+          "url": "http://127.0.0.1:1/mcp",
+          "enabled": true
+        }
+      ]
+    }"#;
+    let cfg = write_cfg(dir.path(), registry);
+    let gw = common::spawn_gateway(&cfg).await;
+
+    // Give spawn attempts a moment (spawn_timeout 2s; boot may still be finishing).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let url = format!("http://127.0.0.1:{}/ready", gw.port);
+    let resp = reqwest::get(&url).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "body: {:?}",
+        resp.text().await
+    );
+}

--- a/crates/vmcp/tests/registry_reload.rs
+++ b/crates/vmcp/tests/registry_reload.rs
@@ -1,0 +1,215 @@
+//! Registry hot-reload via `POST /api/v1/upstreams/reload` (no process restart).
+
+mod common;
+
+use std::time::Duration;
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::*;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::{schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler};
+use serde::Deserialize;
+use vmcp_auth::static_tokens::{append_atomic, generate_entry, SCOPE_ADMIN};
+
+const DEMO_ARGON2: &str = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8";
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct EchoArgs {
+    #[serde(default)]
+    msg: Option<String>,
+}
+
+#[derive(Clone)]
+struct Echo {
+    #[allow(dead_code)]
+    tool_router: ToolRouter<Echo>,
+}
+
+#[tool_router]
+impl Echo {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(description = "Echo back the provided message.")]
+    async fn echo(
+        &self,
+        Parameters(args): Parameters<EchoArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let msg = args.msg.unwrap_or_else(|| "pong".to_string());
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for Echo {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("echo-http", "0.0.0"))
+    }
+}
+
+async fn start_echo_upstream() -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let allowed = vec![
+        "127.0.0.1".to_string(),
+        addr.to_string(),
+        format!("localhost:{}", addr.port()),
+    ];
+    let config = StreamableHttpServerConfig::default().with_allowed_hosts(allowed);
+    let service = StreamableHttpService::new(
+        || Ok(Echo::new()),
+        LocalSessionManager::default().into(),
+        config,
+    );
+    let app = axum::Router::new().nest_service("/mcp", service);
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (addr.port(), handle)
+}
+
+fn write_config(dir: &std::path::Path, tokens: &std::path::Path) -> std::path::PathBuf {
+    std::fs::write(dir.join("registry.json"), br#"{"upstreams":[]}"#).unwrap();
+    std::fs::create_dir_all(dir.join("state")).unwrap();
+    std::fs::create_dir_all(dir.join("specs")).unwrap();
+    std::fs::create_dir_all(dir.join("skills")).unwrap();
+    let config_path = dir.join("vmcp.toml");
+    let config = format!(
+        r#"
+host = "127.0.0.1"
+public_base_url = "http://127.0.0.1:8765"
+registry_path = "{reg}"
+lock_path     = "{lock}"
+spec_dir      = "{spec}"
+skills_dir    = "{skills}"
+
+[gql]
+max_depth = 10
+max_complexity = 1000
+
+[upstream]
+spawn_timeout_ms = 30000
+call_timeout_ms  = 60000
+
+[auth]
+enabled = true
+master_password_argon2 = "{argon}"
+jwt_kid = "test"
+jwks_rotate_secs = 86400
+token_ttl_secs = 3600
+tokens_file = "{tokens}"
+clients_db_path = "{clients}"
+"#,
+        reg = dir.join("registry.json").display(),
+        lock = dir.join("tools.lock.json").display(),
+        spec = dir.join("specs").display(),
+        skills = dir.join("skills").display(),
+        argon = DEMO_ARGON2,
+        tokens = tokens.display(),
+        clients = dir.join("state").join("clients.db").display(),
+    );
+    std::fs::write(&config_path, config).unwrap();
+    config_path
+}
+
+#[tokio::test]
+async fn reload_adds_http_upstream_without_restart() {
+    let (echo_port, _echo) = start_echo_upstream().await;
+    let dir = common::TempDir::new("vmcp-registry-reload");
+    let tokens = dir.path().join("tokens.json");
+    let admin = generate_entry("operator", Some(SCOPE_ADMIN)).unwrap();
+    append_atomic(&tokens, &admin).unwrap();
+    let cfg = write_config(dir.path(), &tokens);
+    let gw = common::spawn_gateway_auth(&cfg).await;
+    let client = reqwest::Client::new();
+    let auth = format!("Bearer {}", admin.token);
+
+    // Empty pool initially
+    let resp = client
+        .get(format!("http://127.0.0.1:{}/api/v1/upstreams", gw.port))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["upstreams"].as_array().unwrap().is_empty());
+
+    // Atomic registry write adding echo HTTP upstream
+    let reg = dir.path().join("registry.json");
+    let reg_body = serde_json::json!({
+        "upstreams": [{
+            "name": "echo",
+            "description": "hot-reloaded echo",
+            "transport": "http",
+            "url": format!("http://127.0.0.1:{echo_port}/mcp"),
+            "enabled": true
+        }]
+    });
+    let tmp = reg.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_vec_pretty(&reg_body).unwrap()).unwrap();
+    std::fs::rename(&tmp, &reg).unwrap();
+
+    // Force reload via API (also exercises the same path as the watcher).
+    let resp = client
+        .post(format!(
+            "http://127.0.0.1:{}/api/v1/upstreams/reload",
+            gw.port
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let report: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        report["added"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == "echo"),
+        "report: {report}"
+    );
+
+    let resp = client
+        .get(format!("http://127.0.0.1:{}/api/v1/upstreams", gw.port))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let ups = body["upstreams"].as_array().unwrap();
+    assert_eq!(ups.len(), 1);
+    assert_eq!(ups[0]["name"], "echo");
+    assert_eq!(ups[0]["connected"], true);
+    assert!(ups[0]["tool_count"].as_u64().unwrap() >= 1);
+
+    // Remove upstream and reload
+    let empty = serde_json::json!({ "upstreams": [] });
+    let tmp = reg.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_vec_pretty(&empty).unwrap()).unwrap();
+    std::fs::rename(&tmp, &reg).unwrap();
+    let resp = client
+        .post(format!(
+            "http://127.0.0.1:{}/api/v1/upstreams/reload",
+            gw.port
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let report: serde_json::Value = resp.json().await.unwrap();
+    assert!(report["removed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|v| v == "echo"));
+}

--- a/crates/vmcp/tests/scope_enforce.rs
+++ b/crates/vmcp/tests/scope_enforce.rs
@@ -1,0 +1,211 @@
+//! Scope enforcement: `upstream:` whitelist blocks other GraphQL namespaces.
+
+mod common;
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::*;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::{schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler};
+use serde::Deserialize;
+use vmcp_auth::static_tokens::{append_atomic, generate_entry};
+
+const DEMO_ARGON2: &str = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8";
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct EchoArgs {
+    #[serde(default)]
+    msg: Option<String>,
+}
+
+#[derive(Clone)]
+struct Echo {
+    #[allow(dead_code)]
+    tool_router: ToolRouter<Echo>,
+}
+
+#[tool_router]
+impl Echo {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(description = "Echo back the provided message.")]
+    async fn echo(
+        &self,
+        Parameters(args): Parameters<EchoArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let msg = args.msg.unwrap_or_else(|| "pong".to_string());
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for Echo {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("echo-http", "0.0.0"))
+    }
+}
+
+async fn start_echo(name: &str) -> (u16, tokio::task::JoinHandle<()>) {
+    let _ = name;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let allowed = vec![
+        "127.0.0.1".to_string(),
+        addr.to_string(),
+        format!("localhost:{}", addr.port()),
+    ];
+    let config = StreamableHttpServerConfig::default().with_allowed_hosts(allowed);
+    let service = StreamableHttpService::new(
+        || Ok(Echo::new()),
+        LocalSessionManager::default().into(),
+        config,
+    );
+    let app = axum::Router::new().nest_service("/mcp", service);
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+    (addr.port(), handle)
+}
+
+#[tokio::test]
+async fn upstream_scope_blocks_other_server() {
+    let (port_a, _ha) = start_echo("alpha").await;
+    let (port_b, _hb) = start_echo("beta").await;
+
+    let dir = common::TempDir::new("vmcp-scope-enforce");
+    let tokens = dir.path().join("tokens.json");
+    let scoped = generate_entry("agent", Some("mcp:use upstream:alpha")).unwrap();
+    append_atomic(&tokens, &scoped).unwrap();
+
+    let registry = serde_json::json!({
+        "upstreams": [
+            {
+                "name": "alpha",
+                "transport": "http",
+                "url": format!("http://127.0.0.1:{port_a}/mcp"),
+                "enabled": true
+            },
+            {
+                "name": "beta",
+                "transport": "http",
+                "url": format!("http://127.0.0.1:{port_b}/mcp"),
+                "enabled": true
+            }
+        ]
+    });
+    std::fs::write(
+        dir.path().join("registry.json"),
+        serde_json::to_vec_pretty(&registry).unwrap(),
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("state")).unwrap();
+    std::fs::create_dir_all(dir.path().join("specs")).unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+
+    let cfg = dir.path().join("vmcp.toml");
+    std::fs::write(
+        &cfg,
+        format!(
+            r#"
+host = "127.0.0.1"
+public_base_url = "http://127.0.0.1:8765"
+registry_path = "{reg}"
+lock_path     = "{lock}"
+spec_dir      = "{spec}"
+skills_dir    = "{skills}"
+
+[gql]
+max_depth = 10
+max_complexity = 1000
+
+[upstream]
+spawn_timeout_ms = 30000
+call_timeout_ms  = 60000
+
+[auth]
+enabled = true
+master_password_argon2 = "{argon}"
+jwt_kid = "test"
+jwks_rotate_secs = 86400
+token_ttl_secs = 3600
+tokens_file = "{tokens}"
+clients_db_path = "{clients}"
+"#,
+            reg = dir.path().join("registry.json").display(),
+            lock = dir.path().join("tools.lock.json").display(),
+            spec = dir.path().join("specs").display(),
+            skills = dir.path().join("skills").display(),
+            argon = DEMO_ARGON2,
+            tokens = tokens.display(),
+            clients = dir.path().join("state").join("clients.db").display(),
+        ),
+    )
+    .unwrap();
+
+    let gw = common::spawn_gateway_auth(&cfg).await;
+    let client =
+        common::connect_client_with_token(NullClient, gw.mcp_url.clone(), Some(&scoped.token))
+            .await;
+
+    // Echo has no readOnlyHint → Mutation bucket.
+    let gql = |server: &str, msg: &str| {
+        format!("mutation {{ {server} {{ echo(msg: \"{msg}\") {{ text isError }} }} }}")
+    };
+
+    // Allowed namespace
+    let ok = client
+        .call_tool(
+            CallToolRequestParams::new("query_graphql").with_arguments(
+                serde_json::json!({ "query": gql("alpha", "hi") })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("alpha call");
+    let ok_text = format!("{ok:?}");
+    assert!(
+        ok_text.contains("hi") && !ok_text.contains("forbidden"),
+        "alpha should be allowed: {ok_text}"
+    );
+
+    // Denied namespace
+    let denied = client
+        .call_tool(
+            CallToolRequestParams::new("query_graphql").with_arguments(
+                serde_json::json!({ "query": gql("beta", "nope") })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("beta call returns tool result");
+    let denied_text = format!("{denied:?}");
+    assert!(
+        denied_text.contains("forbidden") || denied_text.contains("upstream:beta"),
+        "beta should be forbidden: {denied_text}"
+    );
+
+    client.cancel().await.ok();
+}
+
+#[derive(Clone, Default)]
+struct NullClient;
+
+impl rmcp::ClientHandler for NullClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::default(),
+            Implementation::new("scope-test", "0.0.0"),
+        )
+    }
+}

--- a/demo/README.md
+++ b/demo/README.md
@@ -18,7 +18,10 @@
 - бинарь `vmcp` (release с GitHub) **или** `cargo run -p vmcp`
 - `uv` (для `uvx`)
 - Node.js / `npx`
-- `agent-lsp` + `pyright` (`npm i -g pyright`)
+- `agent-lsp` + language servers:
+  - demo Python: `pip install agent-lsp` + `npm i -g pyright`
+  - this Rust workspace: `pip install agent-lsp` + `rustup component add rust-analyzer`
+    then `./scripts/run-agent-lsp.sh` → MCP HTTP on `http://127.0.0.1:8766`
 
 ## Поднять
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,33 @@
+# vmcp on Kubernetes (Gateway API)
+
+Minimal manifests for a **single-replica** gateway. Not HA (RWO PVC + in-memory
+upstream pool). Not a CRD operator.
+
+## Important truths
+
+| Topic | Reality |
+| ----- | ------- |
+| Registry writes | **Operator / ConfigMap** owns `registry.json`. vmcp watches + reloads; it does not write the CM. Prefer `POST /api/v1/upstreams/reload` after apply (inotify on CM `..data` is best-effort). |
+| Image | Set `REPLACE_WITH_BUILT_IMAGE` to a build from **this branch** (main/`v1.0.x` may lack `/api/v1`). |
+| Tokens | Must be on the **PVC** (writable). Run `job-bootstrap-tokens.yaml` once. RO Secret mounts break token CRUD. |
+| Stdio upstreams | Runtime image has no Node/`uv` — use **HTTP** upstreams in cluster. |
+| `/api/v1` | Only when `auth.enabled` + `tokens_file`; requires Bearer `mcp:admin` (also full MCP). Keep on **internal** HTTPRoute. |
+| `/ready` | Soft: 503 if registry has enabled upstreams and none are connected. |
+
+## Apply order
+
+```bash
+kubectl create ns vmcp
+# create Secret vmcp-auth (see secret.example.yaml)
+kubectl apply -f pvc.yaml -f configmap.yaml -f service.yaml
+kubectl apply -f job-bootstrap-tokens.yaml
+kubectl apply -f deployment.yaml
+# optional:
+kubectl apply -f httproute.example.yaml -f networkpolicy.example.yaml
+```
+
+## Operator reconcile loop
+
+1. Update Upstream CM / rewrite mounted `registry.json`.
+2. `POST /api/v1/upstreams/reload` with admin Bearer; check `registry_sha256` / `mtime_unix_ms`.
+3. Mint agent tokens via `POST /api/v1/tokens` (or `PUT …/tokens/:id` to rotate).

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmcp-config
+  namespace: vmcp
+data:
+  vmcp.toml: |
+    host = "0.0.0.0"
+    port = 8765
+    public_base_url = "https://gateway.example.com"
+    registry_path = "/data/registry.json"
+    lock_path = "/state/tools.lock.json"
+    spec_dir = "/data/specs"
+    skills_dir = "/data/skills"
+
+    [gql]
+    max_depth = 10
+    max_complexity = 2000
+
+    [upstream]
+    spawn_timeout_ms = 30000
+    call_timeout_ms = 60000
+
+    [auth]
+    enabled = true
+    issuer = "https://gateway.example.com"
+    # Set via Secret env VMCP_AUTH__MASTER_PASSWORD_ARGON2 (do NOT put REPLACE_ME here).
+    master_password_argon2 = ""
+    tokens_file = "/state/tokens.json"
+    clients_db_path = "/state/clients.db"
+    jwks_private_key_pem_path = "/state/jwks.pem"
+    dcr_enabled = true
+    dcr_max_clients = 256
+    # dcr_redirect_uri_allowlist = ["http://127.0.0.1", "http://localhost", "cursor://"]
+
+    [recorder]
+    sessions_dir = "/state/sessions"
+
+    [tasks]
+    enabled = true
+    db_path = "/state/tasks.db"
+    max_concurrent = 16
+
+  registry.json: |
+    {"upstreams": []}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmcp-data-dirs
+  namespace: vmcp
+data:
+  # Placeholder so /data/specs and /data/skills exist (mount as subPaths).
+  .keep: ""

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmcp
+  namespace: vmcp
+  labels:
+    app: vmcp
+spec:
+  replicas: 1  # HA not supported (RWO PVC + in-memory pool) — see README
+  selector:
+    matchLabels:
+      app: vmcp
+  template:
+    metadata:
+      labels:
+        app: vmcp
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: vmcp
+          # Build/push from this PR branch until a release includes /api/v1.
+          # Example: docker build -t ghcr.io/<org>/vmcp:edge . && docker push ...
+          image: REPLACE_WITH_BUILT_IMAGE
+          imagePullPolicy: Always
+          args: ["serve", "--config", "/config/vmcp.toml"]
+          ports:
+            - name: http
+              containerPort: 8765
+          env:
+            - name: VMCP_HOST
+              value: "0.0.0.0"
+            - name: VMCP_PUBLIC_BASE_URL
+              value: "https://gateway.example.com"
+            - name: VMCP_AUTH__ISSUER
+              value: "https://gateway.example.com"
+            - name: VMCP_AUTH__MASTER_PASSWORD_ARGON2
+              valueFrom:
+                secretKeyRef:
+                  name: vmcp-auth
+                  key: master_password_argon2
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: data-registry
+              mountPath: /data/registry.json
+              subPath: registry.json
+              readOnly: true
+            - name: data-specs
+              mountPath: /data/specs
+              readOnly: true
+            - name: data-skills
+              mountPath: /data/skills
+              readOnly: true
+            - name: state
+              mountPath: /state
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: vmcp-config
+            items:
+              - key: vmcp.toml
+                path: vmcp.toml
+        - name: data-registry
+          configMap:
+            name: vmcp-config
+            items:
+              - key: registry.json
+                path: registry.json
+        - name: data-specs
+          emptyDir: {}
+        - name: data-skills
+          emptyDir: {}
+        - name: state
+          persistentVolumeClaim:
+            claimName: vmcp-state
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/httproute.example.yaml
+++ b/deploy/k8s/httproute.example.yaml
@@ -1,0 +1,47 @@
+# PUBLIC surface — OAuth + MCP + health. Do NOT expose /api/v1 or /admin here.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmcp-public
+  namespace: vmcp
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: gateway-system
+  hostnames:
+    - gateway.example.com
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: /mcp }
+        - path: { type: PathPrefix, value: /mcp-proxy }
+        - path: { type: PathPrefix, value: /authorize }
+        - path: { type: PathPrefix, value: /consent }
+        - path: { type: PathPrefix, value: /token }
+        - path: { type: PathPrefix, value: /register }
+        - path: { type: PathPrefix, value: /.well-known }
+        - path: { type: Exact, value: /health }
+        - path: { type: Exact, value: /ready }
+      backendRefs:
+        - name: vmcp
+          port: 8765
+---
+# INTERNAL control-plane — Bearer mcp:admin (+ /admin Basic). Bind to an
+# internal Gateway / private hostname. mcp:admin also grants full MCP access.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmcp-internal
+  namespace: vmcp
+spec:
+  parentRefs:
+    - name: gateway-internal
+      namespace: gateway-system
+  hostnames:
+    - vmcp-internal.example.svc
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: /api/v1 }
+        - path: { type: PathPrefix, value: /admin }
+      backendRefs:
+        - name: vmcp
+          port: 8765

--- a/deploy/k8s/job-bootstrap-tokens.yaml
+++ b/deploy/k8s/job-bootstrap-tokens.yaml
@@ -1,0 +1,40 @@
+# One-shot: ensure /state/tokens.json has an mcp:admin operator token on the PVC.
+# Requires an image that contains `vmcp` (same as Deployment).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vmcp-bootstrap-tokens
+  namespace: vmcp
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: bootstrap
+          image: REPLACE_WITH_BUILT_IMAGE
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              TOKENS=/state/tokens.json
+              if [ ! -s "$TOKENS" ] || [ "$(cat "$TOKENS")" = "[]" ]; then
+                echo '[]' > "$TOKENS"
+                /usr/local/bin/vmcp pre-reg --name operator --scope mcp:admin --out "$TOKENS"
+                echo "wrote operator token to $TOKENS"
+              else
+                echo "tokens file already present; skip"
+              fi
+              chmod 600 "$TOKENS" || true
+          volumeMounts:
+            - name: state
+              mountPath: /state
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: vmcp-state

--- a/deploy/k8s/networkpolicy.example.yaml
+++ b/deploy/k8s/networkpolicy.example.yaml
@@ -1,0 +1,21 @@
+# Example: only allow public Gateway + same-namespace clients to reach vmcp.
+# Tighten further so /api/v1 is only reachable from operator namespaces.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vmcp
+  namespace: vmcp
+spec:
+  podSelector:
+    matchLabels:
+      app: vmcp
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8765

--- a/deploy/k8s/pvc.yaml
+++ b/deploy/k8s/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vmcp-state
+  namespace: vmcp
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/k8s/secret.example.yaml
+++ b/deploy/k8s/secret.example.yaml
@@ -1,0 +1,14 @@
+# Create real secrets (do not commit digests/tokens):
+#   kubectl -n vmcp create secret generic vmcp-auth \
+#     --from-literal=master_password_argon2="$(vmcp hash-password --password '…')"
+#
+# Tokens must live on the PVC (writable) — use job-bootstrap-tokens.yaml.
+# A read-only Secret mount of tokens.json breaks POST /api/v1/tokens.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vmcp-auth
+  namespace: vmcp
+type: Opaque
+stringData:
+  master_password_argon2: "REPLACE_WITH_REAL_ARGON2_HASH"

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vmcp
+  namespace: vmcp
+spec:
+  selector:
+    app: vmcp
+  ports:
+    - name: http
+      port: 8765
+      targetPort: http

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,6 +10,7 @@
 | `/mcp-proxy` | то же (если `[proxy]`) | Transparent upstream tools |
 | `/admin` | HTTP Basic (master password) | Operator SPA |
 | `/health` | нет | Liveness |
+| `/ready` | нет | Readiness (soft: ≥1 connected upstream, если в registry есть enabled) |
 | `/authorize`, `/consent`, `/token`, `/register`, `/.well-known/*` | нет | OAuth + metadata |
 
 ---
@@ -119,11 +120,83 @@ curl -H "Authorization: Bearer vmcp_…" https://gateway.example.com/mcp
 
 Не истекают (revoke = удали строку), hot-reload без рестарта, OAuth работает параллельно.
 
+Для operator/k8s удобнее HTTP API (см. ниже), чем править файл вручную.
+
+### Scopes (enforced)
+
+Строка `scope` — space-separated. Проверяется на `query_graphql` / `/mcp-proxy` / `run_task`:
+
+| Scope | Значение |
+| ----- | -------- |
+| `mcp:use` | Полный доступ (как раньше; default у `pre-reg`) |
+| `mcp:admin` | Control-plane `/api/v1` + полный MCP доступ |
+| `mcp:read` | Только Query / readOnly tools |
+| `mcp:write` | Query + Mutation |
+| `upstream:<name>` | Whitelist GraphQL namespace / proxy server (если есть хоть один — режим whitelist) |
+| `deny:<server>.<tool>` | Запрет конкретного tool поверх grants |
+
+Пример: `--scope 'mcp:use upstream:time'` — агент не вызовет `postgres.*`.
+
+> **G25:** enforce режет **вызовы**. GraphQL schema / `search` / introspection пока могут
+> **показывать** чужие namespaces — не считать scopes полной изоляцией каталога.
+
+> **G30:** DCR / OAuth consent **не** выдают `mcp:admin` (strips). Admin только через
+> `pre-reg` / `/api/v1/tokens` с operator Bearer.
+
+Static tokens **бессрочные** (G34); нет last-used/TTL в API. Храни `tokens.json` как secret;
+rotate: `PUT /api/v1/tokens/:client_id`. Файл max ~2 MiB / 10k entries (G33).
+
+`/api/v1` монтируется **только** при `auth.enabled` + нужен `tokens_file` для Token CRUD (G13).
+
+---
+
+## Operator API `/api/v1` (Bearer)
+
+Параллельно `/admin` (HTTP Basic). Automation ходит сюда с static bearer, у которого в `scope` есть **`mcp:admin`**.
+
+Bootstrap:
+
+```bash
+vmcp pre-reg --name operator --scope mcp:admin --out ./tokens.json
+```
+
+| Method | Path | Описание |
+| ------ | ---- | -------- |
+| `GET` | `/api/v1/tokens` | Список без полного секрета (`token_prefix`) |
+| `POST` | `/api/v1/tokens` | `{ "name", "scope"? }` → полный `token` **один раз**; duplicate `name` → 409; unknown scope tokens → 400 |
+| `PUT` | `/api/v1/tokens/:client_id` | Rotate secret (same name/scope); полный `token` один раз |
+| `DELETE` | `/api/v1/tokens/:client_id` | Revoke; нельзя удалить последний `mcp:admin` → 400 |
+| `GET` | `/api/v1/upstreams` | Status live pool |
+| `POST` | `/api/v1/upstreams/reload` | Reconcile `registry.json` без рестарта; ответ включает `registry_sha256` / `mtime_unix_ms` |
+
+```bash
+curl -H "Authorization: Bearer $OPERATOR_TOKEN" \
+  -H 'content-type: application/json' \
+  https://gateway.example.com/api/v1/tokens \
+  -d '{"name":"agent-a","scope":"mcp:use"}'
+```
+
+Без Bearer → 401; Bearer с `mcp:use` (без `mcp:admin`) → 403.  
+`/admin` SPA + Basic **не менялись**.
+
 ---
 
 ## DCR clients (переживают restart)
 
 `POST /register` пишет каждый client в **SQLite** (`auth.clients_db_path`, default `state/clients.db`) + hot cache в DashMap. После рестарта store перечитывается — Cursor не ловит `unknown client_id`.
+
+### DCR policy
+
+```toml
+[auth]
+dcr_enabled = true          # false → POST /register = 403 (pre-reg tokens остаются)
+dcr_max_clients = 256       # 0 = без лимита
+dcr_redirect_uri_allowlist = ["http://127.0.0.1", "http://localhost", "cursor://"]
+```
+
+Пустой allowlist = как раньше (любой `redirect_uri`). Rate-limit на `/register` лучше на Envoy; vmcp даёт policy hooks выше. Успешные registration пишутся в audit log (`DCR client registered`).
+
+Черновые k8s манифесты: [`deploy/k8s/`](../deploy/k8s/).
 
 Каждая registration получает уникальное `name` (`cursor`, `cursor-2`, …). Переименовать в admin UI или:
 
@@ -171,7 +244,17 @@ Bearer middleware не монтируется, `/admin` скрывается. **
 
 ## JWT
 
-- Подписаны ротируемым in-memory ключом (`jwks_rotate_secs`, default 86400).
+- Подписаны ротируемым RS256 ключом (`jwks_rotate_secs`, default 86400).
 - `token_ttl_secs` default 3600; должно быть `jwks_rotate_secs >= 2 * token_ttl_secs`.
 - Rotation держит предыдущий `kid` (окно из 2 ключей) — неистёкшие JWT ещё принимаются.
-- **Restart = новый JWKS** → старые JWT мертвы. Для automation бери static tokens.
+- **По умолчанию restart = новый JWKS** → старые JWT мертвы. Для automation бери static tokens.
+- Опционально persist ключа на PVC:
+
+```toml
+[auth]
+jwks_private_key_pem_path = "/state/jwks.pem"  # load or generate+write 0600
+```
+
+Тогда JWT переживают restart. Пишется PKCS#1 PEM + атомарный
+`<path>.bundle.json` с **current и previous** ключами (окно ротации переживает
+pod recreate — G14/G31). Env: `VMCP_AUTH__JWKS_PRIVATE_KEY_PEM_PATH`.

--- a/docs/badges/coverage.json
+++ b/docs/badges/coverage.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "coverage",
-  "message": "97.23%",
+  "message": "96.70%",
   "color": "brightgreen"
 }

--- a/docs/builds-and-modes.md
+++ b/docs/builds-and-modes.md
@@ -32,6 +32,8 @@ docker build --target runtime --build-arg FEATURES="--no-default-features" -t vm
 | `/mcp-proxy` | Опциональный transparent proxy upstream `tools/*` + `prompts/*` (`[proxy] enabled = true`) |
 | `/admin` | Панель оператора (feature `admin`) |
 | `/health` | Liveness |
+| `/ready` | Readiness (upstreams soft) |
+| `/api/v1/*` | Operator JSON (Bearer `mcp:admin`) |
 
 Когда нужен: удалённые клиенты (Cursor/Claude/HTTP), несколько клиентов с OAuth, admin UI + запись сессий.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,6 +21,11 @@ vmcp — один Rust binary. В production ставь за TLS (Caddy/nginx) �
 
 ---
 
+## Kubernetes (черновик)
+
+Манифесты Gateway API + PVC + probes: [`deploy/k8s/`](../deploy/k8s/).  
+Operator reconcile: правь `registry.json` / `POST /api/v1/upstreams/reload`, токены через `/api/v1/tokens` (Bearer `mcp:admin`).
+
 ## Docker Compose (рекомендуется)
 
 Stack: **vmcp** (GHCR image) + **Caddy** (TLS на 80/443).

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -11,6 +11,13 @@ upstream-инструментов, не превращая каждый GraphQL-
 
 Устойчивые строки задач живут во **встроенном SQLite** (WAL).
 
+### Логи клиенту (MCP logging)
+
+При lifecycle `run_task` (enqueue / call / completed / failed) vmcp публикует
+`notifications/message` с `logger = "tasks/<task_id>"` на внутренний bus —
+то же, что форвардится подключённым `/mcp` клиентам (capability `logging`).
+Не путать с admin sessions dump: для long-running tasks слушайте MCP logging.
+
 ---
 
 ## Включение

--- a/docs/upstreams.md
+++ b/docs/upstreams.md
@@ -23,6 +23,17 @@ Env: `VMCP_REGISTRY_PATH`, `VMCP_SPEC_DIR`, `VMCP_LOCK_PATH`, `VMCP_SKILLS_DIR`,
 Демо-стенд: [`demo/vmcp.toml`](../demo/vmcp.toml) + [`demo/README.md`](../demo/README.md)
 (paths и `[upstream]` timeouts уже в toml — не задавай частичный `VMCP_UPSTREAM__*`).
 
+### Ограничения (operator)
+
+| Тема | Поведение |
+| ---- | --------- |
+| Skills с диска | Hot-reload **нет** — правки YAML требуют restart, либо Admin Skills CRUD (G07) |
+| Stdio в cluster image | Runtime image без Node/`uv` — в k8s используй **HTTP** upstreams (G08) |
+| HA | Один replica + RWO PVC; pool/schema in-memory — multi-replica **не** поддерживается (G12) |
+| Health | `connected` обновляется по RPC outcome; idle dead upstream без вызовов может долго казаться up (G24) |
+| `${ENV}` | Missing var → **ошибка** load registry (strict) |
+| Размер registry | Max **256** upstreams; duplicate `name` → ошибка |
+
 ---
 
 ## 1. Upstream-сервисы (`registry.json`)
@@ -117,10 +128,15 @@ tools/list → CachedTool → sidecar overrides → ResolvedTool → GraphQL + t
 | GraphQL schema | `ArcSwap` + `swap_schema` | Атомарная подмена |
 | Skills | Admin CRUD → reload | Без рестарта |
 | Static tokens | `vmcp-watch` на `tokens_file` | Hot-reload после rename |
+| **Registry (`registry.json`)** | recursive watch + mtime poll + `POST /api/v1/upstreams/reload` | Add/remove/replace upstreams, rebuild schema. В k8s CM надёжнее вызывать API reload после apply |
 | Upstream prompts | `prompts/list_changed` → `refresh_prompts` | Кэш + forward клиентам |
-| Upstream tools | `tools/list_changed` | Пока forward клиентам; `detect_drift`/`swap_schema` — задел под drift-handler |
+| Upstream tools | `tools/list_changed` → `refresh_tools` + rebuild GraphQL | Кэш + schema + forward клиентам |
 
-`vmcp-watch` — общий file-watcher (parent dir + фильтр по имени, переживает tmp→rename). Сейчас висит на `tokens_file`; тот же примитив — под registry/skills.
+`vmcp-watch` — общий file-watcher (parent dir + фильтр по имени, переживает tmp→rename). Висит на `tokens_file` и на `registry_path`.
+
+Operator status: `GET /api/v1/upstreams` (Bearer `mcp:admin`) — `connected`, `tool_count`, `last_error`, `last_ok_unix_ms`.  
+Readiness probe: `GET /ready` (soft: если в registry есть enabled upstreams и ни один не `connected` → 503; `/health` остаётся liveness).  
+Legacy `GET /admin/api/servers` без изменений.
 
 ---
 

--- a/scripts/run-agent-lsp.sh
+++ b/scripts/run-agent-lsp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run agent-lsp (MCP over HTTP) for this vmcp workspace with rust-analyzer.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${AGENT_LSP_PORT:-8766}"
+BIN="${AGENT_LSP_BIN:-}"
+if [[ -z "$BIN" ]]; then
+  if command -v agent-lsp >/dev/null 2>&1; then
+    BIN="$(command -v agent-lsp)"
+  elif [[ -x "$HOME/.local/lib/python3.12/site-packages/agent_lsp/bin/agent-lsp" ]]; then
+    BIN="$HOME/.local/lib/python3.12/site-packages/agent_lsp/bin/agent-lsp"
+  else
+    echo "Install: pip install agent-lsp && rustup component add rust-analyzer" >&2
+    exit 1
+  fi
+fi
+mkdir -p /tmp/agent-lsp
+exec "$BIN" --http --port "$PORT" --no-auth "rust:rust-analyzer"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Operator-facing changes so a Kubernetes controller can reconcile vmcp **without rolling restarts**. The `/admin` Basic SPA is unchanged.

### Control plane
- `GET` / `POST` / `PUT` / `DELETE` `/api/v1/tokens` (Bearer `mcp:admin`; same `tokens.json` format as `vmcp pre-reg`)
- `GET` / `POST` `/api/v1/upstreams` and `/api/v1/upstreams/reload` (includes registry content hash / mtime)
- Soft `GET /ready` — 503 when the registry has enabled upstreams but none are connected

### Hot reload
- Registry file watcher (recursive + mtime poll) and HTTP reload
- Upstream `tools/list_changed` refreshes tool cache and rebuilds GraphQL
- `run_task` allowlist updates after successful reload; TaskRunner is created whenever tasks are enabled (even if the registry starts empty)

### Auth / security
- Scope validation for static tokens and OAuth/DCR paths
- Strict `${ENV}` expansion in registry; duplicate upstream names rejected
- Description-only registry edits do not respawn sessions
- JWKS optional persist: PEM + atomic bundle with current and previous keys
- DCR: redirect allowlist by host, max-clients under a mutex, `mcp:admin` stripped from DCR/consent
- Soft caps on token file size/count and upstream count

### Deploy
- `deploy/k8s/` examples: PVC, bootstrap Job for tokens, split public/internal HTTPRoutes, NetworkPolicy, resources/securityContext
- Image placeholder must be built from this branch until a release includes `/api/v1`
- `.github/workflows/ci.yml` — fmt, clippy, tests, coverage gates

### Known limits (documented)
- Skills YAML on disk: no hot-reload (Admin CRUD or restart)
- Cluster image: HTTP upstreams only (no Node/`uv` for stdio demos)
- Single replica / RWO PVC — not HA
- Scope enforcement blocks calls; schema/search may still list other namespaces
- Idle upstream health is RPC-driven (no active probes yet)

## Test plan
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` and integration tests (`ready`, `api_v1_tokens`, `registry_reload`, `scope_enforce`)
- [x] Coverage gates: vmcp-server ≥96%, vmcp-admin ≥99%
- [x] `cargo machete` — no unused deps
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-772bf4d4-27cb-487e-95fe-7983811d9e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-772bf4d4-27cb-487e-95fe-7983811d9e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

