### PR TITLE
feat(auth): facade for local OAuth and Authentik

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: OpenSSL headers (async-oidc-jwt-validator / reqwest native-tls)
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -35,8 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: OpenSSL headers (async-oidc-jwt-validator / reqwest native-tls)
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --lib
@@ -46,8 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: OpenSSL headers (async-oidc-jwt-validator / reqwest native-tls)
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,7 @@ jobs:
           cargo llvm-cov -p vmcp-admin --lib
           --fail-under-lines 99
           --ignore-filename-regex '(integration|ui_regression|pages)\.rs'
+      - name: vmcp-auth ≥93%
+        run: >
+          cargo llvm-cov -p vmcp-auth --lib
+          --fail-under-lines 93

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: OpenSSL headers (async-oidc-jwt-validator / reqwest native-tls)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -33,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: OpenSSL headers (async-oidc-jwt-validator / reqwest native-tls)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --lib
@@ -42,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: OpenSSL headers (async-oidc-jwt-validator / reqwest native-tls)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,20 +255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-oidc-jwt-validator"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a1a56d1ea16c6285f4ec9f7c225e4808274dda7ac1228cfc704faf5cbf3d4e"
-dependencies = [
- "jsonwebtoken",
- "log",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,16 +617,6 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -959,21 +935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,25 +1106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "handlebars"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1247,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1334,22 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,11 +1292,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1817,23 +1740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,47 +1887,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2562,20 +2431,15 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2586,7 +2450,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -2801,7 +2664,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2927,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3308,27 +3171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,16 +3313,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3914,7 +3746,6 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "argon2",
- "async-oidc-jwt-validator",
  "axum",
  "base64 0.22.1",
  "chrono",
@@ -3923,6 +3754,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "rand 0.8.7",
+ "reqwest 0.12.28",
  "rsa",
  "rusqlite",
  "serde",
@@ -4272,17 +4104,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-oidc-jwt-validator"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a1a56d1ea16c6285f4ec9f7c225e4808274dda7ac1228cfc704faf5cbf3d4e"
+dependencies = [
+ "jsonwebtoken",
+ "log",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +631,16 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -935,6 +959,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1145,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "handlebars"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1305,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1275,6 +1334,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,9 +1367,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1740,6 +1817,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,10 +1981,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -2431,15 +2562,20 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2450,6 +2586,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -2664,7 +2801,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2790,7 +2927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3171,6 +3308,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3471,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3746,6 +3914,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "argon2",
+ "async-oidc-jwt-validator",
  "axum",
  "base64 0.22.1",
  "chrono",
@@ -4103,6 +4272,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ ARG FEATURES
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         gcc-mingw-w64-x86-64 \
+        pkg-config \
+        libssl-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add ${TARGET}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         gcc-mingw-w64-x86-64 \
         pkg-config \
-        libssl-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add ${TARGET}

--- a/crates/vmcp-admin/src/auth.rs
+++ b/crates/vmcp-admin/src/auth.rs
@@ -34,11 +34,12 @@ pub struct AdminAuth {
 }
 
 /// Runtime policy for the `/admin` gate (from `[auth.admin]`).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum AdminAuthPolicy {
     /// No authentication.
     None,
     /// HTTP Basic against the master password hash on [`AdminState`].
+    #[default]
     Basic,
     /// Authentik forward-auth headers.
     Authentik {
@@ -47,12 +48,6 @@ pub enum AdminAuthPolicy {
         /// Exact group names (any one is enough).
         required_groups: Vec<String>,
     },
-}
-
-impl Default for AdminAuthPolicy {
-    fn default() -> Self {
-        Self::Basic
-    }
 }
 
 pub async fn require_admin_auth(
@@ -66,7 +61,7 @@ pub async fn require_admin_auth(
                 subject: "anonymous".into(),
                 source: AdminAuthSource::None,
             });
-            return next.run(req).await;
+            next.run(req).await
         }
         AdminAuthPolicy::Basic => {
             // Prefer the real peer address from the listener; fall back to loopback

--- a/crates/vmcp-admin/src/auth.rs
+++ b/crates/vmcp-admin/src/auth.rs
@@ -1,15 +1,16 @@
-//! HTTP Basic auth middleware against the master password hash.
+//! `/admin` auth facade: `none` | HTTP Basic (`user:pass`) | Authentik headers.
 //!
-//! Username is ignored — only the password is checked. Mirrors Python admin's
-//! UX: browser shows the native prompt, no login form, no cookie session,
-//! no CSRF surface. Per-IP rate limiter blocks brute-force at 429.
+//! - **none** — open (local/dev only); never invent a fake identity, just skip the gate.
+//! - **basic** — `Authorization: Basic` against `master_password_argon2`.
+//! - **authentik** — trust `X-authentik-username` / `X-authentik-groups` from the
+//!   gateway; exact group membership after delimiter split; missing headers → 401.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use axum::{
     body::Body,
     extract::{ConnectInfo, State},
-    http::{header, Request, StatusCode},
+    http::{header, HeaderMap, HeaderName, Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -17,67 +18,167 @@ use base64::Engine;
 
 use crate::AdminState;
 
-/// Marker that an auth check succeeded (cleared the rate limiter etc).
-#[derive(Clone, Copy, Debug)]
-pub struct AdminAuth;
+/// How the admin identity was established.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdminAuthSource {
+    None,
+    Basic,
+    AuthentikHeaders,
+}
 
-pub async fn require_basic_auth(
+/// Marker (+ subject) that an auth check succeeded.
+#[derive(Clone, Debug)]
+pub struct AdminAuth {
+    pub subject: String,
+    pub source: AdminAuthSource,
+}
+
+/// Runtime policy for the `/admin` gate (from `[auth.admin]`).
+#[derive(Clone, Debug)]
+pub enum AdminAuthPolicy {
+    /// No authentication.
+    None,
+    /// HTTP Basic against the master password hash on [`AdminState`].
+    Basic,
+    /// Authentik forward-auth headers.
+    Authentik {
+        username_header: HeaderName,
+        groups_header: HeaderName,
+        /// Exact group names (any one is enough).
+        required_groups: Vec<String>,
+    },
+}
+
+impl Default for AdminAuthPolicy {
+    fn default() -> Self {
+        Self::Basic
+    }
+}
+
+pub async fn require_admin_auth(
     State(state): State<AdminState>,
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
-    // Prefer the real peer address from the listener; fall back to loopback
-    // when ConnectInfo is absent (unit/integration tests via oneshot).
-    let ip = req
-        .extensions()
-        .get::<ConnectInfo<SocketAddr>>()
-        .map(|ci| ci.0.ip())
-        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    match &state.admin_auth {
+        AdminAuthPolicy::None => {
+            req.extensions_mut().insert(AdminAuth {
+                subject: "anonymous".into(),
+                source: AdminAuthSource::None,
+            });
+            return next.run(req).await;
+        }
+        AdminAuthPolicy::Basic => {
+            // Prefer the real peer address from the listener; fall back to loopback
+            // when ConnectInfo is absent (unit/integration tests via oneshot).
+            let ip = req
+                .extensions()
+                .get::<ConnectInfo<SocketAddr>>()
+                .map(|ci| ci.0.ip())
+                .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
 
-    if state.rate_limiter.is_blocked(ip) {
-        return (
-            StatusCode::TOO_MANY_REQUESTS,
-            [(header::RETRY_AFTER, "60")],
-            "rate limited",
-        )
-            .into_response();
+            if state.rate_limiter.is_blocked(ip) {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [(header::RETRY_AFTER, "60")],
+                    "rate limited",
+                )
+                    .into_response();
+            }
+
+            let auth_header = req
+                .headers()
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+
+            let (user, password) = match auth_header.as_deref().and_then(decode_basic) {
+                Some(p) => p,
+                None => return unauthorized_basic(),
+            };
+
+            let ok =
+                vmcp_auth::password::verify_master(&password, &state.master_hash).unwrap_or(false);
+
+            if !ok {
+                state.rate_limiter.record_failure(ip);
+                return unauthorized_basic();
+            }
+
+            let subject = if user.is_empty() {
+                "admin".into()
+            } else {
+                user
+            };
+            req.extensions_mut().insert(AdminAuth {
+                subject,
+                source: AdminAuthSource::Basic,
+            });
+            next.run(req).await
+        }
+        AdminAuthPolicy::Authentik {
+            username_header,
+            groups_header,
+            required_groups,
+        } => match authenticate_authentik_headers(
+            req.headers(),
+            username_header,
+            groups_header,
+            required_groups,
+        ) {
+            Ok(subject) => {
+                req.extensions_mut().insert(AdminAuth {
+                    subject,
+                    source: AdminAuthSource::AuthentikHeaders,
+                });
+                next.run(req).await
+            }
+            Err(resp) => resp,
+        },
     }
-
-    let auth_header = req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-
-    let password = match auth_header.as_deref().and_then(decode_basic) {
-        Some(p) => p,
-        None => return unauthorized_response(),
-    };
-
-    let ok = vmcp_auth::password::verify_master(&password, &state.master_hash).unwrap_or(false);
-
-    if !ok {
-        state.rate_limiter.record_failure(ip);
-        return unauthorized_response();
-    }
-
-    req.extensions_mut().insert(AdminAuth);
-    next.run(req).await
 }
 
-/// Parse `Authorization: Basic base64(user:pass)`. Returns the password
-/// portion (we ignore the username — single-tenant admin).
-fn decode_basic(header_value: &str) -> Option<String> {
+fn authenticate_authentik_headers(
+    headers: &HeaderMap,
+    username_header: &HeaderName,
+    groups_header: &HeaderName,
+    required_groups: &[String],
+) -> Result<String, Response> {
+    let username = headers
+        .get(username_header)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| unauthorized_forward("missing X-authentik-username"))?;
+
+    let groups_raw = headers
+        .get(groups_header)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let groups = vmcp_auth::split_groups(groups_raw);
+
+    let allowed = required_groups
+        .iter()
+        .any(|need| vmcp_auth::group_contains(&groups, need));
+    if !allowed {
+        return Err(unauthorized_forward("insufficient_group"));
+    }
+    Ok(username.to_string())
+}
+
+/// Parse `Authorization: Basic base64(user:pass)`.
+/// Returns `(username, password)`. Username may be empty.
+fn decode_basic(header_value: &str) -> Option<(String, String)> {
     let rest = header_value.strip_prefix("Basic ")?;
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(rest.trim())
         .ok()?;
     let s = std::str::from_utf8(&decoded).ok()?;
-    let (_user, pass) = s.split_once(':')?;
-    Some(pass.to_string())
+    let (user, pass) = s.split_once(':')?;
+    Some((user.to_string(), pass.to_string()))
 }
 
-fn unauthorized_response() -> Response {
+fn unauthorized_basic() -> Response {
     (
         StatusCode::UNAUTHORIZED,
         [(
@@ -89,16 +190,21 @@ fn unauthorized_response() -> Response {
         .into_response()
 }
 
+fn unauthorized_forward(reason: &'static str) -> Response {
+    (StatusCode::UNAUTHORIZED, reason).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::HeaderValue;
 
     #[test]
-    fn decode_basic_extracts_password() {
+    fn decode_basic_extracts_user_and_password() {
         // base64("admin:hunter2") = "YWRtaW46aHVudGVyMg=="
         assert_eq!(
             decode_basic("Basic YWRtaW46aHVudGVyMg=="),
-            Some("hunter2".into())
+            Some(("admin".into(), "hunter2".into()))
         );
     }
 
@@ -110,6 +216,30 @@ mod tests {
     #[test]
     fn decode_basic_handles_password_with_colons() {
         // base64("u:a:b:c") = "dTphOmI6Yw=="
-        assert_eq!(decode_basic("Basic dTphOmI6Yw=="), Some("a:b:c".into()));
+        assert_eq!(
+            decode_basic("Basic dTphOmI6Yw=="),
+            Some(("u".into(), "a:b:c".into()))
+        );
+    }
+
+    #[test]
+    fn authentik_headers_require_username_and_exact_group() {
+        let user_h = HeaderName::from_static("x-authentik-username");
+        let groups_h = HeaderName::from_static("x-authentik-groups");
+        let required = vec!["mcp-admins".into()];
+
+        let mut headers = HeaderMap::new();
+        let err = authenticate_authentik_headers(&headers, &user_h, &groups_h, &required);
+        assert!(err.is_err());
+
+        headers.insert(&user_h, HeaderValue::from_static("alice"));
+        headers.insert(&groups_h, HeaderValue::from_static("mcp-admins-extra|ops"));
+        // mcp-admins-extra must NOT satisfy mcp-admins
+        assert!(authenticate_authentik_headers(&headers, &user_h, &groups_h, &required).is_err());
+
+        headers.insert(&groups_h, HeaderValue::from_static("ops|mcp-admins"));
+        let subject =
+            authenticate_authentik_headers(&headers, &user_h, &groups_h, &required).unwrap();
+        assert_eq!(subject, "alice");
     }
 }

--- a/crates/vmcp-admin/src/integration.rs
+++ b/crates/vmcp-admin/src/integration.rs
@@ -111,9 +111,23 @@ async fn call(
     auth: Option<&str>,
     body: Option<Value>,
 ) -> (StatusCode, Vec<(String, String)>, Vec<u8>) {
+    call_with_headers(app, method, path, auth, body, &[]).await
+}
+
+async fn call_with_headers(
+    app: axum::Router,
+    method: Method,
+    path: &str,
+    auth: Option<&str>,
+    body: Option<Value>,
+    extra: &[(&str, &str)],
+) -> (StatusCode, Vec<(String, String)>, Vec<u8>) {
     let mut builder = Request::builder().method(method).uri(path);
     if let Some(a) = auth {
         builder = builder.header(header::AUTHORIZATION, a);
+    }
+    for (k, v) in extra {
+        builder = builder.header(*k, *v);
     }
     if body.is_some() {
         builder = builder.header(header::CONTENT_TYPE, "application/json");
@@ -147,6 +161,86 @@ async fn call(
 
 fn json_body(bytes: &[u8]) -> Value {
     serde_json::from_slice(bytes).unwrap_or(Value::Null)
+}
+
+#[tokio::test]
+async fn admin_mode_none_is_open_without_credentials() {
+    use crate::AdminAuthPolicy;
+
+    let skills = TempDir::new("skills-none");
+    let sessions = TempDir::new("sessions-none");
+    let state = test_state(skills.path(), sessions.path())
+        .await
+        .with_admin_auth(AdminAuthPolicy::None);
+    let app = router(state);
+    let (st, _, body) = call(app, Method::GET, "/", None, None).await;
+    assert_eq!(st, StatusCode::OK);
+    assert!(String::from_utf8_lossy(&body).contains("admin.css"));
+    assert!(matches!(AdminAuthPolicy::default(), AdminAuthPolicy::Basic));
+}
+
+#[tokio::test]
+async fn admin_mode_authentik_headers_gate() {
+    use crate::AdminAuthPolicy;
+    use axum::http::HeaderName;
+
+    let skills = TempDir::new("skills-ak");
+    let sessions = TempDir::new("sessions-ak");
+    let state = test_state(skills.path(), sessions.path())
+        .await
+        .with_admin_auth(AdminAuthPolicy::Authentik {
+            username_header: HeaderName::from_static("x-authentik-username"),
+            groups_header: HeaderName::from_static("x-authentik-groups"),
+            required_groups: vec!["mcp-admins".into()],
+        });
+    let app = router(state);
+
+    let (st, _, _) = call(app.clone(), Method::GET, "/", None, None).await;
+    assert_eq!(st, StatusCode::UNAUTHORIZED);
+
+    let (st, _, _) = call_with_headers(
+        app.clone(),
+        Method::GET,
+        "/",
+        None,
+        None,
+        &[
+            ("x-authentik-username", "alice"),
+            ("x-authentik-groups", "mcp-admins-extra|ops"),
+        ],
+    )
+    .await;
+    assert_eq!(st, StatusCode::UNAUTHORIZED, "exact group match only");
+
+    let (st, _, body) = call_with_headers(
+        app,
+        Method::GET,
+        "/",
+        None,
+        None,
+        &[
+            ("x-authentik-username", "alice"),
+            ("x-authentik-groups", "ops|mcp-admins"),
+        ],
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+    assert!(String::from_utf8_lossy(&body).contains("admin.css"));
+}
+
+#[tokio::test]
+async fn basic_empty_username_subject_defaults_to_admin() {
+    let skills = TempDir::new("skills-empty-user");
+    let sessions = TempDir::new("sessions-empty-user");
+    let state = test_state(skills.path(), sessions.path()).await;
+    let app = router(state);
+    // base64(":test-master-pw")
+    let auth = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode(format!(":{MASTER}").as_bytes())
+    );
+    let (st, _, _) = call(app, Method::GET, "/", Some(&auth), None).await;
+    assert_eq!(st, StatusCode::OK);
 }
 
 #[tokio::test]

--- a/crates/vmcp-admin/src/lib.rs
+++ b/crates/vmcp-admin/src/lib.rs
@@ -1,8 +1,8 @@
 //! vmcp operator admin panel.
 //!
-//! Mounted under `/admin` by the bin crate. HTTP Basic auth against the same
-//! argon2id master-password hash that gates `/consent`. Per-IP rate limiter
-//! drops brute-forcers to 429 after a small window of failures.
+//! Mounted under `/admin` by the bin crate. Auth is a facade with three modes
+//! (`none` | HTTP Basic | Authentik headers) from `[auth.admin]`. Per-IP rate
+//! limiter drops Basic brute-forcers to 429 after a small window of failures.
 //!
 //! The UI is a single four-zone SPA (`templates/main.html` +
 //! `static/admin.{css,js}`). CSP is tightened so no inline scripts are
@@ -39,7 +39,7 @@ mod integration;
 #[cfg(test)]
 mod ui_regression;
 
-pub use auth::AdminAuth;
+pub use auth::{AdminAuth, AdminAuthPolicy, AdminAuthSource};
 pub use rate_limit::RateLimiter;
 
 /// Shared state for every admin route. Cheap to clone (everything is `Arc`).
@@ -57,8 +57,10 @@ pub struct AdminState {
     /// paths (`list_skills`, MCP `prompts/*`) never take this lock — they
     /// snapshot through the `ArcSwap`.
     pub skills_write_lock: Arc<tokio::sync::Mutex<()>>,
-    /// PHC-encoded argon2id master password hash.
+    /// PHC-encoded argon2id master password hash (used when policy is Basic).
     pub master_hash: Arc<String>,
+    /// `/admin` auth facade policy (`none` | `basic` | `authentik`).
+    pub admin_auth: AdminAuthPolicy,
     pub rate_limiter: Arc<RateLimiter>,
     /// OAuth/DCR registered clients — source of `pre_registered` state in
     /// the Sessions aggregation.
@@ -90,17 +92,24 @@ impl AdminState {
             skills_dir,
             skills_write_lock: Arc::new(tokio::sync::Mutex::new(())),
             master_hash: Arc::new(master_hash),
+            admin_auth: AdminAuthPolicy::Basic,
             rate_limiter: Arc::new(RateLimiter::new(10, std::time::Duration::from_secs(60))),
             auth_state,
             registry,
             recorder,
         }
     }
+
+    /// Override the `/admin` auth policy (default is HTTP Basic).
+    pub fn with_admin_auth(mut self, policy: AdminAuthPolicy) -> Self {
+        self.admin_auth = policy;
+        self
+    }
 }
 
 /// Mount all `/admin/*` routes onto a new router. The bin nests this under
 /// `/admin` via `.nest("/admin", vmcp_admin::router(state))`. Every route is
-/// fronted by HTTP Basic + rate limiter + security headers.
+/// fronted by the admin auth facade + security headers.
 pub fn router(state: AdminState) -> Router {
     let static_dir = resolve_static_dir();
 
@@ -110,7 +119,7 @@ pub fn router(state: AdminState) -> Router {
         .nest_service("/static", tower_http::services::ServeDir::new(static_dir))
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
-            auth::require_basic_auth,
+            auth::require_admin_auth,
         ))
         .layer(axum::middleware::from_fn(security::headers))
         .with_state(state)

--- a/crates/vmcp-auth/Cargo.toml
+++ b/crates/vmcp-auth/Cargo.toml
@@ -27,6 +27,8 @@ percent-encoding = { workspace = true }
 rsa = { version = "0.9", features = ["pem"] }
 base64 = "0.22"
 sha2 = "0.10"
+# Authentik / external OIDC: JWKS fetch + cache (jsonwebtoken 9 compatible).
+async-oidc-jwt-validator = "0.1.2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/vmcp-auth/Cargo.toml
+++ b/crates/vmcp-auth/Cargo.toml
@@ -27,8 +27,9 @@ percent-encoding = { workspace = true }
 rsa = { version = "0.9", features = ["pem"] }
 base64 = "0.22"
 sha2 = "0.10"
-# Authentik / external OIDC: JWKS fetch + cache (jsonwebtoken 9 compatible).
-async-oidc-jwt-validator = "0.1.2"
+# Authentik remote JWKS over the same rustls stack as upstream MCP clients —
+# never pull OpenSSL via reqwest default native-tls.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/vmcp-auth/src/facade.rs
+++ b/crates/vmcp-auth/src/facade.rs
@@ -1,0 +1,157 @@
+//! Auth facade: one gate for local OAuth and external Authentik.
+//!
+//! Browser traffic (forward-auth) and machine MCP clients (Bearer JWT) are
+//! different clients — this facade is the single place that turns either into
+//! a normalized [`AuthIdentity`] on **every** request. Downstream scope checks
+//! always see a resolved identity; there is no anonymous / default role.
+
+use axum::http::{header, HeaderMap};
+
+use crate::providers::authentik::AuthentikAuth;
+use crate::providers::local::LocalAuth;
+use crate::types::AccessTokenClaims;
+
+/// How the identity was established (audit / debugging).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthSource {
+    /// Local AS JWT (vmcp-issued RS256).
+    LocalJwt,
+    /// Pre-registered opaque `vmcp_…` token.
+    StaticToken,
+    /// Authentik-issued Bearer JWT verified against remote JWKS.
+    AuthentikJwt,
+    /// Trusted gateway forward-auth headers (`X-authentik-*`).
+    AuthentikForwardAuth,
+}
+
+/// Normalized identity after a successful authenticate call.
+#[derive(Debug, Clone)]
+pub struct AuthIdentity {
+    pub subject: String,
+    pub client_id: String,
+    pub scope: String,
+    pub groups: Vec<String>,
+    pub issuer: String,
+    pub audience: String,
+    pub iat: i64,
+    pub exp: i64,
+    pub jti: String,
+    pub source: AuthSource,
+}
+
+impl AuthIdentity {
+    /// Project into the claims type already consumed by MCP / GraphQL / admin.
+    pub fn into_claims(self) -> AccessTokenClaims {
+        AccessTokenClaims {
+            iss: self.issuer,
+            aud: self.audience,
+            sub: self.subject,
+            client_id: self.client_id,
+            scope: self.scope,
+            iat: self.iat,
+            exp: self.exp,
+            jti: self.jti,
+        }
+    }
+}
+
+/// Why authentication failed. Mapped to WWW-Authenticate `error=…`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthReject {
+    MissingBearer,
+    EmptyBearer,
+    InvalidToken,
+    /// Forward-auth: required Authentik header absent — never invent identity.
+    MissingForwardAuthHeader(&'static str),
+    /// Authenticated but no MCP scope after group mapping.
+    InsufficientScope,
+}
+
+impl AuthReject {
+    pub fn as_error_code(&self) -> &'static str {
+        match self {
+            Self::MissingBearer => "missing_bearer",
+            Self::EmptyBearer => "empty_bearer",
+            Self::InvalidToken => "invalid_token",
+            Self::MissingForwardAuthHeader(_) => "missing_forward_auth",
+            Self::InsufficientScope => "insufficient_scope",
+        }
+    }
+}
+
+/// Facade over local OAuth AS/RS and Authentik (JWT + forward-auth).
+///
+/// Clone is cheap (`Arc` inside each variant). Middleware holds this as state.
+#[derive(Clone)]
+pub enum AuthFacade {
+    Local(LocalAuth),
+    Authentik(AuthentikAuth),
+}
+
+impl AuthFacade {
+    /// Authenticate **this** request. Must be called on every protected request;
+    /// never cache a default role when credentials/headers are omitted.
+    pub async fn authenticate(&self, headers: &HeaderMap) -> Result<AuthIdentity, AuthReject> {
+        match self {
+            Self::Local(p) => p.authenticate(headers),
+            Self::Authentik(p) => p.authenticate(headers).await,
+        }
+    }
+
+    /// Issuer(s) advertised in Protected Resource Metadata `authorization_servers`.
+    pub fn authorization_servers(&self) -> Vec<String> {
+        match self {
+            Self::Local(p) => vec![p.state.issuer.clone()],
+            Self::Authentik(p) => vec![p.issuer.clone()],
+        }
+    }
+
+    /// Primary resource indicator for bare PRM + WWW-Authenticate.
+    pub fn resource(&self) -> &str {
+        match self {
+            Self::Local(p) => p.state.resource_audience.as_str(),
+            Self::Authentik(p) => p.resource.as_str(),
+        }
+    }
+
+    /// All accepted resource audiences (`/mcp`, `/mcp-proxy`, …).
+    pub fn resource_audiences(&self) -> &[String] {
+        match self {
+            Self::Local(p) => &p.state.resource_audiences,
+            Self::Authentik(p) => &p.audiences,
+        }
+    }
+
+    /// Whether vmcp should mount the local OAuth AS (`/authorize`, DCR, …).
+    pub fn serves_local_as(&self) -> bool {
+        matches!(self, Self::Local(_))
+    }
+
+    /// `WWW-Authenticate` challenge for 401 responses.
+    pub fn www_authenticate(&self, error: &str) -> String {
+        let base = match self {
+            Self::Local(p) => p.state.issuer.trim_end_matches('/').to_string(),
+            Self::Authentik(p) => p.resource.trim_end_matches('/').to_string(),
+        };
+        let prm = format!("{base}/.well-known/oauth-protected-resource");
+        format!("Bearer resource_metadata=\"{prm}\", error=\"{error}\"")
+    }
+
+    /// Extract Bearer raw token if present.
+    pub(crate) fn bearer_token(headers: &HeaderMap) -> Result<Option<&str>, AuthReject> {
+        let Some(value) = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+        else {
+            return Ok(None);
+        };
+        let Some(token) = value.strip_prefix("Bearer ") else {
+            return Ok(None);
+        };
+        let token = token.trim();
+        if token.is_empty() {
+            return Err(AuthReject::EmptyBearer);
+        }
+        Ok(Some(token))
+    }
+}

--- a/crates/vmcp-auth/src/facade.rs
+++ b/crates/vmcp-auth/src/facade.rs
@@ -155,3 +155,128 @@ impl AuthFacade {
         Ok(Some(token))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jwks::JwksManager;
+    use crate::providers::authentik::{AuthentikAuth, AuthentikConfig};
+    use crate::providers::local::LocalAuth;
+    use crate::state::AuthState;
+    use axum::http::HeaderValue;
+    use std::collections::BTreeMap;
+
+    const DUMMY_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$YWFhYWFhYWFhYWFhYWFhYQ$dG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4";
+
+    fn local_facade() -> AuthFacade {
+        let jwks = JwksManager::new_with_fresh("facade").unwrap();
+        let state = AuthState::new(jwks, "https://iss", "https://iss/mcp", 3600, DUMMY_HASH);
+        AuthFacade::Local(LocalAuth::new(state))
+    }
+
+    fn authentik_facade() -> AuthFacade {
+        let mut group_scopes = BTreeMap::new();
+        group_scopes.insert("mcp-users".into(), "mcp:use".into());
+        AuthFacade::Authentik(
+            AuthentikAuth::new(AuthentikConfig {
+                issuer: "https://auth.example/application/o/mcp/".into(),
+                jwks_url: "https://auth.example/application/o/mcp/jwks/".into(),
+                audiences: vec!["https://mcp.example/mcp".into()],
+                resource: "https://mcp.example/mcp".into(),
+                accept_bearer: false,
+                forward_auth: true,
+                group_scopes,
+                ..Default::default()
+            })
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn reject_codes_cover_all_variants() {
+        assert_eq!(AuthReject::MissingBearer.as_error_code(), "missing_bearer");
+        assert_eq!(AuthReject::EmptyBearer.as_error_code(), "empty_bearer");
+        assert_eq!(AuthReject::InvalidToken.as_error_code(), "invalid_token");
+        assert_eq!(
+            AuthReject::MissingForwardAuthHeader("x").as_error_code(),
+            "missing_forward_auth"
+        );
+        assert_eq!(
+            AuthReject::InsufficientScope.as_error_code(),
+            "insufficient_scope"
+        );
+    }
+
+    #[test]
+    fn into_claims_preserves_identity_fields() {
+        let id = AuthIdentity {
+            subject: "u".into(),
+            client_id: "c".into(),
+            scope: "mcp:use".into(),
+            groups: vec!["g".into()],
+            issuer: "iss".into(),
+            audience: "aud".into(),
+            iat: 1,
+            exp: 2,
+            jti: "j".into(),
+            source: AuthSource::LocalJwt,
+        };
+        let c = id.into_claims();
+        assert_eq!(c.sub, "u");
+        assert_eq!(c.client_id, "c");
+        assert_eq!(c.scope, "mcp:use");
+        assert_eq!(c.aud, "aud");
+    }
+
+    #[test]
+    fn local_facade_metadata_helpers() {
+        let f = local_facade();
+        assert!(f.serves_local_as());
+        assert_eq!(f.resource(), "https://iss/mcp");
+        assert_eq!(f.authorization_servers(), vec!["https://iss".to_string()]);
+        assert_eq!(f.resource_audiences(), &["https://iss/mcp".to_string()]);
+        let challenge = f.www_authenticate("missing_bearer");
+        assert!(challenge.contains("resource_metadata="));
+        assert!(challenge.contains("missing_bearer"));
+    }
+
+    #[tokio::test]
+    async fn authentik_facade_metadata_and_forward_auth() {
+        let f = authentik_facade();
+        assert!(!f.serves_local_as());
+        assert_eq!(f.resource(), "https://mcp.example/mcp");
+        assert_eq!(
+            f.authorization_servers(),
+            vec!["https://auth.example/application/o/mcp/".to_string()]
+        );
+        assert!(f
+            .www_authenticate("x")
+            .contains("https://mcp.example/mcp/.well-known/oauth-protected-resource"));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-authentik-username", HeaderValue::from_static("alice"));
+        headers.insert("x-authentik-groups", HeaderValue::from_static("mcp-users"));
+        let id = f.authenticate(&headers).await.unwrap();
+        assert_eq!(id.source, AuthSource::AuthentikForwardAuth);
+        assert_eq!(id.scope, "mcp:use");
+    }
+
+    #[test]
+    fn bearer_token_empty_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::AUTHORIZATION, HeaderValue::from_static("Bearer   "));
+        assert_eq!(
+            AuthFacade::bearer_token(&headers).unwrap_err(),
+            AuthReject::EmptyBearer
+        );
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Token abc"),
+        );
+        assert_eq!(AuthFacade::bearer_token(&headers).unwrap(), None);
+        assert_eq!(
+            AuthFacade::bearer_token(&HeaderMap::new()).unwrap(),
+            None
+        );
+    }
+}

--- a/crates/vmcp-auth/src/facade.rs
+++ b/crates/vmcp-auth/src/facade.rs
@@ -269,14 +269,8 @@ mod tests {
             AuthFacade::bearer_token(&headers).unwrap_err(),
             AuthReject::EmptyBearer
         );
-        headers.insert(
-            header::AUTHORIZATION,
-            HeaderValue::from_static("Token abc"),
-        );
+        headers.insert(header::AUTHORIZATION, HeaderValue::from_static("Token abc"));
         assert_eq!(AuthFacade::bearer_token(&headers).unwrap(), None);
-        assert_eq!(
-            AuthFacade::bearer_token(&HeaderMap::new()).unwrap(),
-            None
-        );
+        assert_eq!(AuthFacade::bearer_token(&HeaderMap::new()).unwrap(), None);
     }
 }

--- a/crates/vmcp-auth/src/groups.rs
+++ b/crates/vmcp-auth/src/groups.rs
@@ -1,0 +1,85 @@
+//! Authentik / gateway group header parsing.
+//!
+//! Groups arrive as a single header value with mixed separators. Matching MUST
+//! be exact token equality after split — substring checks would let
+//! `architect-x` inherit rights from `architect`.
+
+/// Delimiters used in this deployment contour for `X-authentik-groups`.
+const GROUP_DELIMS: &[char] = &['|', ',', ';', ' '];
+
+/// Split a raw groups header into exact group names.
+///
+/// Separators: `|`, `,`, `;`, whitespace. Empty segments are dropped.
+/// Order is preserved; duplicates are kept (callers may dedup if needed).
+pub fn split_groups(raw: &str) -> Vec<String> {
+    raw.split(GROUP_DELIMS)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Exact membership check (never substring / prefix).
+pub fn group_contains(groups: &[String], required: &str) -> bool {
+    groups.iter().any(|g| g == required)
+}
+
+/// Map Authentik groups onto a space-separated MCP scope string.
+///
+/// Only **exact** group names from `group_scopes` keys contribute scopes.
+/// Missing map entries are ignored. Result is sorted for stable claims.
+pub fn scopes_from_groups(
+    groups: &[String],
+    group_scopes: &std::collections::BTreeMap<String, String>,
+) -> String {
+    let mut scopes = std::collections::BTreeSet::new();
+    for g in groups {
+        if let Some(mapped) = group_scopes.get(g) {
+            for tok in mapped.split_whitespace() {
+                if !tok.is_empty() {
+                    scopes.insert(tok.to_string());
+                }
+            }
+        }
+    }
+    scopes.into_iter().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn splits_all_supported_delimiters() {
+        let g = split_groups("mcp-users|architect,ops;mcp-admins reader");
+        assert_eq!(
+            g,
+            vec!["mcp-users", "architect", "ops", "mcp-admins", "reader"]
+        );
+    }
+
+    #[test]
+    fn exact_match_not_substring() {
+        let groups = split_groups("architect-x|architect-extra");
+        assert!(!group_contains(&groups, "architect"));
+        assert!(group_contains(&groups, "architect-x"));
+    }
+
+    #[test]
+    fn scopes_require_exact_group_key() {
+        let mut map = BTreeMap::new();
+        map.insert("architect".into(), "mcp:use upstream:architect_c4".into());
+        map.insert("architect-x".into(), "mcp:read".into());
+
+        let scopes = scopes_from_groups(&split_groups("architect-x"), &map);
+        assert_eq!(scopes, "mcp:read");
+        assert!(!scopes.contains("upstream:architect_c4"));
+    }
+
+    #[test]
+    fn empty_or_whitespace_yields_no_groups() {
+        assert!(split_groups("").is_empty());
+        assert!(split_groups("  | , ; ").is_empty());
+    }
+}

--- a/crates/vmcp-auth/src/lib.rs
+++ b/crates/vmcp-auth/src/lib.rs
@@ -17,6 +17,7 @@ pub mod jwks;
 pub mod middleware;
 pub mod password;
 pub mod providers;
+pub mod remote_jwks;
 pub mod router;
 pub mod scopes;
 pub mod state;

--- a/crates/vmcp-auth/src/lib.rs
+++ b/crates/vmcp-auth/src/lib.rs
@@ -1,15 +1,22 @@
-//! OAuth 2.1 Authorization Server + Resource Server in one process.
+//! OAuth 2.1 Authorization Server + Resource Server in one process,
+//! plus an Authentik facade for external IdP deployments.
 //!
 //! Replaces Python `vmcp/auth/{provider,jwt,store,consent}.py`. Same wire
 //! contract: DCR (RFC 7591), authorization code + PKCE, JWT access tokens with
 //! local JWKS rotation, Resource Indicator (RFC 8707), master-password consent.
+//!
+//! When `auth.provider = "authentik"`, vmcp acts only as a resource server:
+//! Bearer JWTs from Authentik and/or forward-auth headers from the gateway.
 
 #![allow(clippy::result_large_err)]
 
 pub mod client_store;
+pub mod facade;
+pub mod groups;
 pub mod jwks;
 pub mod middleware;
 pub mod password;
+pub mod providers;
 pub mod router;
 pub mod scopes;
 pub mod state;
@@ -17,8 +24,11 @@ pub mod static_tokens;
 pub mod tokens;
 pub mod types;
 
-pub use scopes::ScopePolicy;
-
+pub use facade::{AuthFacade, AuthIdentity, AuthReject, AuthSource};
+pub use groups::{group_contains, scopes_from_groups, split_groups};
 pub use middleware::{require_admin_scope, require_bearer};
-pub use router::build_router;
+pub use providers::authentik::{AuthentikAuth, AuthentikConfig};
+pub use providers::local::LocalAuth;
+pub use router::{build_external_rs_router, build_router};
+pub use scopes::ScopePolicy;
 pub use state::{AuthState, DcrPolicy, RenameClientError};

--- a/crates/vmcp-auth/src/lib.rs
+++ b/crates/vmcp-auth/src/lib.rs
@@ -31,4 +31,4 @@ pub use providers::authentik::{AuthentikAuth, AuthentikConfig};
 pub use providers::local::LocalAuth;
 pub use router::{build_external_rs_router, build_router};
 pub use scopes::ScopePolicy;
-pub use state::{AuthState, DcrPolicy, RenameClientError};
+pub use state::{AuthState, DcrPolicy, RenameClientError, AUTH_EPHEMERAL_MAX_AGE};

--- a/crates/vmcp-auth/src/middleware.rs
+++ b/crates/vmcp-auth/src/middleware.rs
@@ -1,4 +1,8 @@
-//! Bearer-auth middleware for protecting `/mcp`.
+//! Bearer / forward-auth middleware for protecting `/mcp`.
+//!
+//! Delegates credential resolution to [`AuthFacade`] so local OAuth and
+//! Authentik share one gate. Scope enforcement still happens downstream on
+//! every tool call via [`crate::scopes::ScopePolicy`].
 
 use axum::{
     body::Body,
@@ -8,90 +12,33 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::state::AuthState;
-use crate::static_tokens::{self, TokenInfo};
-use crate::tokens::verify_access_token;
+use crate::facade::{AuthFacade, AuthReject};
 use crate::types::AccessTokenClaims;
 
-/// Reject if no valid Bearer token. On success, attach the verified claims to
-/// the request extensions so downstream handlers can introspect them.
+/// Reject if authentication fails. On success, attach verified claims so
+/// downstream handlers can introspect them.
 pub async fn require_bearer(
-    State(state): State<AuthState>,
+    State(facade): State<AuthFacade>,
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
-    let header_value = req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok());
-
-    let token = match header_value.and_then(|h| h.strip_prefix("Bearer ")) {
-        Some(t) => t.trim(),
-        None => return unauthorized(&state, "missing_bearer"),
-    };
-    if token.is_empty() {
-        return unauthorized(&state, "empty_bearer");
-    }
-
-    // Static "pre-registered" token fast-path: opaque, eternal, file-backed,
-    // independent of JWKS. A `vmcp_`-prefixed bearer is NEVER a JWT, so a miss
-    // 401s immediately rather than falling through to (futile) JWT verify.
-    // Non-prefixed tokens skip this block and take the JWT path unchanged.
-    if let Some(store) = &state.token_store {
-        if token.starts_with(static_tokens::TOKEN_PREFIX) {
-            return match store.lookup(token) {
-                Some(info) => {
-                    req.extensions_mut()
-                        .insert(synth_static_claims(&state, &info));
-                    next.run(req).await
-                }
-                None => {
-                    tracing::debug!("unknown static token");
-                    unauthorized(&state, "invalid_token")
-                }
-            };
-        }
-    }
-
-    let audiences = state.audience_refs();
-    match verify_access_token(&state.jwks, token, &state.issuer, &audiences) {
-        Ok(claims) => {
-            req.extensions_mut().insert(claims);
+    match facade.authenticate(req.headers()).await {
+        Ok(identity) => {
+            req.extensions_mut().insert(identity.into_claims());
             next.run(req).await
         }
-        Err(e) => {
-            tracing::debug!(error = %e, "bearer rejected");
-            unauthorized(&state, "invalid_token")
-        }
+        Err(reject) => unauthorized(&facade, reject),
     }
 }
 
-/// Build claims for a verified static token. Mirrors the JWT claim shape so
-/// everything downstream (recorder, admin) treats it uniformly. `exp` is set
-/// ~100 years out — far-future but overflow-safe (not `i64::MAX`); nothing
-/// re-validates it after this point, since the static path never expires.
-fn synth_static_claims(state: &AuthState, info: &TokenInfo) -> AccessTokenClaims {
-    let now = chrono::Utc::now().timestamp();
-    let exp = now + 100 * 365 * 24 * 3600;
-    AccessTokenClaims {
-        iss: state.issuer.clone(),
-        aud: state.resource_audience.clone(),
-        sub: info.client_id.clone(),
-        client_id: info.client_id.clone(),
-        scope: info.scope.clone(),
-        iat: now,
-        exp,
-        jti: uuid::Uuid::new_v4().to_string(),
-    }
-}
-
-fn unauthorized(state: &AuthState, error: &str) -> Response {
-    let prm = format!(
-        "{}/.well-known/oauth-protected-resource",
-        state.issuer.trim_end_matches('/')
-    );
-    let challenge = format!("Bearer resource_metadata=\"{prm}\", error=\"{error}\"");
-    let mut resp = (StatusCode::UNAUTHORIZED, error.to_string()).into_response();
+fn unauthorized(facade: &AuthFacade, reject: AuthReject) -> Response {
+    let error = reject.as_error_code();
+    let challenge = facade.www_authenticate(error);
+    let status = match reject {
+        AuthReject::InsufficientScope => StatusCode::FORBIDDEN,
+        _ => StatusCode::UNAUTHORIZED,
+    };
+    let mut resp = (status, error.to_string()).into_response();
     resp.headers_mut().insert(
         header::WWW_AUTHENTICATE,
         challenge.parse().expect("static header value"),
@@ -131,6 +78,8 @@ fn unauthorized_plain(error: &str) -> Response {
 mod tests {
     use super::*;
     use crate::jwks::JwksManager;
+    use crate::providers::local::LocalAuth;
+    use crate::state::AuthState;
     use crate::static_tokens::{self, StaticTokenStore};
     use crate::tokens::issue_access_token;
     use axum::{
@@ -166,14 +115,14 @@ mod tests {
 
     const DUMMY_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$YWFhYWFhYWFhYWFhYWFhYQ$dG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4";
 
-    fn state_with_store(file: &Path) -> AuthState {
+    fn facade_with_store(file: &Path) -> AuthFacade {
         let jwks = JwksManager::new_with_fresh("kid-test").unwrap();
         let store = StaticTokenStore::load(file).unwrap();
-        AuthState::new(jwks, "https://iss", "https://iss", 3600, DUMMY_HASH).with_token_store(store)
+        let state = AuthState::new(jwks, "https://iss", "https://iss", 3600, DUMMY_HASH)
+            .with_token_store(store);
+        AuthFacade::Local(LocalAuth::new(state))
     }
 
-    /// Handler that echoes the resolved `client_id` so tests can assert which
-    /// auth path produced the claims.
     async fn echo_client_id(req: Request<Body>) -> Response {
         match claims_from_extensions(req.extensions()) {
             Some(c) => (StatusCode::OK, c.client_id.clone()).into_response(),
@@ -181,10 +130,10 @@ mod tests {
         }
     }
 
-    fn app(state: AuthState) -> Router {
+    fn app(facade: AuthFacade) -> Router {
         Router::new()
             .route("/mcp", post(echo_client_id))
-            .layer(axum::middleware::from_fn_with_state(state, require_bearer))
+            .layer(axum::middleware::from_fn_with_state(facade, require_bearer))
     }
 
     async fn body_string(resp: Response) -> String {
@@ -210,7 +159,7 @@ mod tests {
         let entry = static_tokens::generate_entry("ci", Some("mcp:use")).unwrap();
         static_tokens::append_atomic(&file, &entry).unwrap();
 
-        let resp = app(state_with_store(&file))
+        let resp = app(facade_with_store(&file))
             .oneshot(bearer_req(&entry.token))
             .await
             .unwrap();
@@ -226,11 +175,10 @@ mod tests {
     async fn unknown_static_token_is_rejected_without_jwt_fallthrough() {
         let dir = TempDir::new();
         let file = dir.path().join("tokens.json");
-        // Store has one token; we present a different vmcp_ token.
         let entry = static_tokens::generate_entry("ci", None).unwrap();
         static_tokens::append_atomic(&file, &entry).unwrap();
 
-        let resp = app(state_with_store(&file))
+        let resp = app(facade_with_store(&file))
             .oneshot(bearer_req("vmcp_definitely-not-registered"))
             .await
             .unwrap();
@@ -240,29 +188,31 @@ mod tests {
     #[tokio::test]
     async fn jwt_path_still_works_when_store_present() {
         let dir = TempDir::new();
-        let file = dir.path().join("tokens.json"); // empty store
-        let state = state_with_store(&file);
-        // A real JWT (no vmcp_ prefix) must bypass the static path entirely.
+        let file = dir.path().join("tokens.json");
+        let facade = facade_with_store(&file);
+        let AuthFacade::Local(local) = &facade else {
+            panic!("expected local");
+        };
         let (jwt, _) = issue_access_token(
-            &state.jwks,
-            &state.issuer,
-            &state.resource_audience,
+            &local.state.jwks,
+            &local.state.issuer,
+            &local.state.resource_audience,
             "jwt-client",
             "mcp:use",
             3600,
         )
         .unwrap();
 
-        let resp = app(state).oneshot(bearer_req(&jwt)).await.unwrap();
+        let resp = app(facade).oneshot(bearer_req(&jwt)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(body_string(resp).await, "jwt-client");
     }
 
-    fn admin_app(state: AuthState) -> Router {
+    fn admin_app(facade: AuthFacade) -> Router {
         Router::new()
             .route("/api/v1/ping", post(echo_client_id))
             .layer(axum::middleware::from_fn(require_admin_scope))
-            .layer(axum::middleware::from_fn_with_state(state, require_bearer))
+            .layer(axum::middleware::from_fn_with_state(facade, require_bearer))
     }
 
     fn admin_bearer_req(token: &str) -> Request<Body> {
@@ -282,21 +232,21 @@ mod tests {
         let agent = static_tokens::generate_entry("agent", Some("mcp:use")).unwrap();
         static_tokens::append_atomic(&file, &admin).unwrap();
         static_tokens::append_atomic(&file, &agent).unwrap();
-        let state = state_with_store(&file);
+        let facade = facade_with_store(&file);
 
-        let ok = admin_app(state.clone())
+        let ok = admin_app(facade.clone())
             .oneshot(admin_bearer_req(&admin.token))
             .await
             .unwrap();
         assert_eq!(ok.status(), StatusCode::OK);
 
-        let forbidden = admin_app(state.clone())
+        let forbidden = admin_app(facade.clone())
             .oneshot(admin_bearer_req(&agent.token))
             .await
             .unwrap();
         assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
 
-        let missing = admin_app(state)
+        let missing = admin_app(facade)
             .oneshot(
                 Request::builder()
                     .uri("/api/v1/ping")

--- a/crates/vmcp-auth/src/middleware.rs
+++ b/crates/vmcp-auth/src/middleware.rs
@@ -225,6 +225,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authentik_insufficient_scope_returns_forbidden() {
+        use crate::providers::authentik::{AuthentikAuth, AuthentikConfig};
+        use std::collections::BTreeMap;
+
+        let mut group_scopes = BTreeMap::new();
+        group_scopes.insert("mcp-users".into(), "mcp:use".into());
+        let facade = AuthFacade::Authentik(
+            AuthentikAuth::new(AuthentikConfig {
+                issuer: "https://auth.example/".into(),
+                jwks_url: "https://auth.example/jwks/".into(),
+                audiences: vec!["https://mcp.example/mcp".into()],
+                resource: "https://mcp.example/mcp".into(),
+                accept_bearer: false,
+                forward_auth: true,
+                group_scopes,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        let resp = app(facade)
+            .oneshot(
+                Request::builder()
+                    .uri("/mcp")
+                    .method("POST")
+                    .header("x-authentik-username", "alice")
+                    .header("x-authentik-groups", "unrelated")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(resp.headers().get(header::WWW_AUTHENTICATE).is_some());
+    }
+
+    #[tokio::test]
+    async fn require_admin_scope_missing_claims_is_unauthorized() {
+        // Hit require_admin_scope without require_bearer → missing claims path.
+        let bare = Router::new()
+            .route("/api/v1/ping", post(echo_client_id))
+            .layer(axum::middleware::from_fn(require_admin_scope));
+        let resp = bare
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/ping")
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
     async fn require_admin_scope_allows_mcp_admin_rejects_mcp_use() {
         let dir = TempDir::new();
         let file = dir.path().join("tokens.json");

--- a/crates/vmcp-auth/src/providers/authentik.rs
+++ b/crates/vmcp-auth/src/providers/authentik.rs
@@ -1,0 +1,343 @@
+//! Authentik provider via [`async_oidc_jwt_validator`] (JWKS cache + OIDC checks)
+//! plus optional forward-auth headers from a trusted gateway.
+//!
+//! Contract:
+//! 1. Trust gateway headers only when present — never invent anonymous / default role.
+//! 2. Split groups on `|`, `,`, `;`, space and match **exactly** (not substring).
+//! 3. Resolve scopes from groups on **every** request (no omitted-parameter bypass).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_oidc_jwt_validator::{Algorithm, OidcConfig, OidcValidator, Validation};
+use axum::http::{HeaderMap, HeaderName};
+use chrono::Utc;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::facade::{AuthFacade, AuthIdentity, AuthReject, AuthSource};
+use crate::groups::{scopes_from_groups, split_groups};
+
+/// Configuration snapshot for Authentik-backed auth.
+#[derive(Debug, Clone)]
+pub struct AuthentikConfig {
+    /// OIDC issuer (e.g. `https://auth.example.com/application/o/mcp-internal/`).
+    pub issuer: String,
+    /// JWKS URL for signature verification.
+    pub jwks_url: String,
+    /// Accepted JWT `aud` values / resource indicators.
+    pub audiences: Vec<String>,
+    /// Canonical resource URL advertised in Protected Resource Metadata.
+    pub resource: String,
+    /// Accept `Authorization: Bearer` JWTs from Authentik.
+    pub accept_bearer: bool,
+    /// Accept `X-authentik-*` forward-auth headers from the gateway.
+    pub forward_auth: bool,
+    /// Header carrying the username (default `x-authentik-username`).
+    pub username_header: String,
+    /// Header carrying groups (default `x-authentik-groups`).
+    pub groups_header: String,
+    /// JWT claim name for groups (default `groups`).
+    pub groups_claim: String,
+    /// Exact group name → space-separated MCP scopes.
+    pub group_scopes: BTreeMap<String, String>,
+}
+
+impl Default for AuthentikConfig {
+    fn default() -> Self {
+        Self {
+            issuer: String::new(),
+            jwks_url: String::new(),
+            audiences: Vec::new(),
+            resource: String::new(),
+            accept_bearer: true,
+            forward_auth: true,
+            username_header: "x-authentik-username".into(),
+            groups_header: "x-authentik-groups".into(),
+            groups_claim: "groups".into(),
+            group_scopes: BTreeMap::new(),
+        }
+    }
+}
+
+/// Authentik auth provider (OIDC resource server + optional forward-auth).
+#[derive(Clone)]
+pub struct AuthentikAuth {
+    pub issuer: String,
+    pub audiences: Vec<String>,
+    pub resource: String,
+    accept_bearer: bool,
+    forward_auth: bool,
+    username_header: HeaderName,
+    groups_header: HeaderName,
+    groups_claim: String,
+    group_scopes: BTreeMap<String, String>,
+    validator: Arc<OidcValidator>,
+}
+
+impl AuthentikAuth {
+    pub fn new(cfg: AuthentikConfig) -> anyhow::Result<Self> {
+        let username_header = HeaderName::from_bytes(cfg.username_header.as_bytes())
+            .map_err(|e| anyhow::anyhow!("invalid username_header: {e}"))?;
+        let groups_header = HeaderName::from_bytes(cfg.groups_header.as_bytes())
+            .map_err(|e| anyhow::anyhow!("invalid groups_header: {e}"))?;
+
+        // `client_id` in OidcConfig is the default `aud` for `validate()`;
+        // we always use `validate_custom` with resource audiences instead.
+        let primary_aud = cfg
+            .audiences
+            .first()
+            .cloned()
+            .unwrap_or_else(|| cfg.resource.clone());
+        let oidc = OidcConfig::new(cfg.issuer.clone(), primary_aud, cfg.jwks_url);
+        let validator = OidcValidator::new(oidc);
+
+        Ok(Self {
+            issuer: cfg.issuer,
+            audiences: cfg.audiences,
+            resource: cfg.resource,
+            accept_bearer: cfg.accept_bearer,
+            forward_auth: cfg.forward_auth,
+            username_header,
+            groups_header,
+            groups_claim: cfg.groups_claim,
+            group_scopes: cfg.group_scopes,
+            validator: Arc::new(validator),
+        })
+    }
+
+    pub async fn authenticate(&self, headers: &HeaderMap) -> Result<AuthIdentity, AuthReject> {
+        // Machine clients: Bearer first. Browser form redirects are not viable.
+        if self.accept_bearer {
+            if let Some(token) = AuthFacade::bearer_token(headers)? {
+                return self.authenticate_jwt(token).await;
+            }
+        }
+
+        if self.forward_auth {
+            return self.authenticate_forward_auth(headers);
+        }
+
+        Err(AuthReject::MissingBearer)
+    }
+
+    fn authenticate_forward_auth(&self, headers: &HeaderMap) -> Result<AuthIdentity, AuthReject> {
+        let username = headers
+            .get(&self.username_header)
+            .and_then(|v| v.to_str().ok())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or(AuthReject::MissingForwardAuthHeader("X-authentik-username"))?;
+
+        // Absent groups header → empty groups (no default role).
+        let groups_raw = headers
+            .get(&self.groups_header)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let groups = split_groups(groups_raw);
+        let scope = scopes_from_groups(&groups, &self.group_scopes);
+        if scope.is_empty() {
+            return Err(AuthReject::InsufficientScope);
+        }
+
+        let now = Utc::now().timestamp();
+        let audience = self
+            .audiences
+            .first()
+            .cloned()
+            .unwrap_or_else(|| self.resource.clone());
+
+        Ok(AuthIdentity {
+            subject: username.to_string(),
+            client_id: username.to_string(),
+            scope,
+            groups,
+            issuer: self.issuer.clone(),
+            audience,
+            iat: now,
+            exp: now + 3600,
+            jti: Uuid::new_v4().to_string(),
+            source: AuthSource::AuthentikForwardAuth,
+        })
+    }
+
+    async fn authenticate_jwt(&self, token: &str) -> Result<AuthIdentity, AuthReject> {
+        let mut validation = Validation::new(Algorithm::RS256);
+        let aud_refs: Vec<&str> = self.audiences.iter().map(String::as_str).collect();
+        validation.set_audience(&aud_refs);
+        validation.set_issuer(&[&self.issuer]);
+        validation.validate_aud = true;
+        validation.validate_exp = true;
+
+        let claims: AuthentikClaims = self
+            .validator
+            .validate_custom(token, &validation)
+            .await
+            .map_err(|e| {
+                tracing::debug!(error = %e, "authentik jwt rejected");
+                AuthReject::InvalidToken
+            })?;
+
+        let groups = self.extract_groups(&claims);
+        let mut scope = claims.scope.unwrap_or_default();
+        let mapped = scopes_from_groups(&groups, &self.group_scopes);
+        if scope.is_empty() {
+            scope = mapped;
+        } else if !mapped.is_empty() {
+            let mut set: std::collections::BTreeSet<String> =
+                scope.split_whitespace().map(str::to_string).collect();
+            for tok in mapped.split_whitespace() {
+                set.insert(tok.to_string());
+            }
+            scope = set.into_iter().collect::<Vec<_>>().join(" ");
+        }
+        if scope.is_empty() {
+            return Err(AuthReject::InsufficientScope);
+        }
+
+        let subject = claims
+            .preferred_username
+            .or(claims.sub.clone())
+            .unwrap_or_else(|| "unknown".into());
+        let client_id = claims.client_id.unwrap_or_else(|| subject.clone());
+        let audience = match claims.aud {
+            Aud::One(s) => s,
+            Aud::Many(v) => v
+                .into_iter()
+                .find(|a| self.audiences.iter().any(|e| e == a))
+                .unwrap_or_else(|| self.resource.clone()),
+        };
+
+        Ok(AuthIdentity {
+            subject: subject.clone(),
+            client_id,
+            scope,
+            groups,
+            issuer: claims.iss,
+            audience,
+            iat: claims.iat.unwrap_or_else(|| Utc::now().timestamp()),
+            exp: claims.exp,
+            jti: claims.jti.unwrap_or_else(|| Uuid::new_v4().to_string()),
+            source: AuthSource::AuthentikJwt,
+        })
+    }
+
+    fn extract_groups(&self, claims: &AuthentikClaims) -> Vec<String> {
+        let value = claims
+            .extra
+            .get(&self.groups_claim)
+            .or_else(|| claims.extra.get("groups"));
+        match value {
+            Some(serde_json::Value::String(s)) => split_groups(s),
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+                .filter(|s| !s.is_empty())
+                .collect(),
+            _ => claims
+                .groups
+                .as_ref()
+                .map(|g| {
+                    g.iter()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthentikClaims {
+    iss: String,
+    aud: Aud,
+    #[serde(default)]
+    sub: Option<String>,
+    #[serde(default)]
+    preferred_username: Option<String>,
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    groups: Option<Vec<String>>,
+    #[serde(default)]
+    iat: Option<i64>,
+    exp: i64,
+    #[serde(default)]
+    jti: Option<String>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Aud {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facade::AuthSource;
+    use axum::http::{HeaderMap, HeaderValue};
+
+    fn cfg_forward() -> AuthentikConfig {
+        let mut group_scopes = BTreeMap::new();
+        group_scopes.insert("mcp-users".into(), "mcp:use".into());
+        group_scopes.insert("architect".into(), "mcp:use upstream:architect_c4".into());
+        AuthentikConfig {
+            issuer: "https://auth.example.com/application/o/mcp-internal/".into(),
+            jwks_url: "https://auth.example.com/application/o/mcp-internal/jwks/".into(),
+            audiences: vec!["https://mcp.example.com/mcp".into()],
+            resource: "https://mcp.example.com/mcp".into(),
+            accept_bearer: false,
+            forward_auth: true,
+            group_scopes,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_auth_requires_username_header() {
+        let auth = AuthentikAuth::new(cfg_forward()).unwrap();
+        let err = auth.authenticate(&HeaderMap::new()).await.unwrap_err();
+        assert_eq!(
+            err,
+            AuthReject::MissingForwardAuthHeader("X-authentik-username")
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_auth_maps_exact_groups_every_request() {
+        let auth = AuthentikAuth::new(cfg_forward()).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-authentik-username", HeaderValue::from_static("alice"));
+        // architect-x must NOT get architect rights (delimiter + exact match).
+        headers.insert(
+            "x-authentik-groups",
+            HeaderValue::from_static("architect-x|mcp-users"),
+        );
+
+        let id = auth.authenticate(&headers).await.unwrap();
+        assert_eq!(id.subject, "alice");
+        assert_eq!(id.scope, "mcp:use");
+        assert_eq!(id.source, AuthSource::AuthentikForwardAuth);
+        assert!(!id.scope.contains("architect_c4"));
+    }
+
+    #[tokio::test]
+    async fn forward_auth_rejects_when_no_mapped_scopes() {
+        let auth = AuthentikAuth::new(cfg_forward()).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-authentik-username", HeaderValue::from_static("bob"));
+        headers.insert(
+            "x-authentik-groups",
+            HeaderValue::from_static("unrelated-group"),
+        );
+        let err = auth.authenticate(&headers).await.unwrap_err();
+        assert_eq!(err, AuthReject::InsufficientScope);
+    }
+}

--- a/crates/vmcp-auth/src/providers/authentik.rs
+++ b/crates/vmcp-auth/src/providers/authentik.rs
@@ -375,10 +375,7 @@ mod tests {
         (format!("http://{addr}/jwks"), handle)
     }
 
-    fn sign_jwt(
-        mgr: &crate::jwks::JwksManager,
-        claims: serde_json::Value,
-    ) -> String {
+    fn sign_jwt(mgr: &crate::jwks::JwksManager, claims: serde_json::Value) -> String {
         use jsonwebtoken::{encode, Algorithm, Header};
         let cur = mgr.current.load();
         let mut header = Header::new(Algorithm::RS256);

--- a/crates/vmcp-auth/src/providers/authentik.rs
+++ b/crates/vmcp-auth/src/providers/authentik.rs
@@ -353,10 +353,19 @@ mod tests {
         assert_eq!(err, AuthReject::MissingBearer);
     }
 
-    /// Local JWKS HTTP mock + RS256 JWT covering Authentik JWT claim/group paths.
-    async fn spawn_jwks_server(
-        jwks_json: serde_json::Value,
-    ) -> (String, tokio::task::JoinHandle<()>) {
+    /// Local JWKS HTTP mock. Aborts the accept loop on drop (no task leak in tests).
+    struct JwksServer {
+        url: String,
+        handle: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for JwksServer {
+        fn drop(&mut self) {
+            self.handle.abort();
+        }
+    }
+
+    async fn spawn_jwks_server(jwks_json: serde_json::Value) -> JwksServer {
         use axum::{routing::get, Json, Router};
         use tokio::net::TcpListener;
 
@@ -372,7 +381,10 @@ mod tests {
         let handle = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        (format!("http://{addr}/jwks"), handle)
+        JwksServer {
+            url: format!("http://{addr}/jwks"),
+            handle,
+        }
     }
 
     fn sign_jwt(mgr: &crate::jwks::JwksManager, claims: serde_json::Value) -> String {
@@ -390,7 +402,7 @@ mod tests {
 
         let mgr = JwksManager::new_with_fresh("ak-jwt").unwrap();
         let jwks_body = serde_json::json!({ "keys": mgr.jwks() });
-        let (jwks_url, _server) = spawn_jwks_server(jwks_body).await;
+        let server = spawn_jwks_server(jwks_body).await;
 
         let issuer = "https://auth.test/application/o/mcp/";
         let audience = "https://mcp.test/mcp";
@@ -400,7 +412,7 @@ mod tests {
 
         let auth = AuthentikAuth::new(AuthentikConfig {
             issuer: issuer.into(),
-            jwks_url,
+            jwks_url: server.url.clone(),
             audiences: vec![audience.into()],
             resource: audience.into(),
             accept_bearer: true,
@@ -449,8 +461,7 @@ mod tests {
         use axum::http::header;
 
         let mgr = JwksManager::new_with_fresh("ak-jwt2").unwrap();
-        let (jwks_url, _server) =
-            spawn_jwks_server(serde_json::json!({ "keys": mgr.jwks() })).await;
+        let server = spawn_jwks_server(serde_json::json!({ "keys": mgr.jwks() })).await;
         let issuer = "https://auth.test/application/o/mcp/";
         let audience = "https://mcp.test/mcp";
         let mut group_scopes = BTreeMap::new();
@@ -458,7 +469,7 @@ mod tests {
 
         let auth = AuthentikAuth::new(AuthentikConfig {
             issuer: issuer.into(),
-            jwks_url,
+            jwks_url: server.url.clone(),
             audiences: vec![audience.into()],
             resource: audience.into(),
             accept_bearer: true,

--- a/crates/vmcp-auth/src/providers/authentik.rs
+++ b/crates/vmcp-auth/src/providers/authentik.rs
@@ -340,4 +340,208 @@ mod tests {
         let err = auth.authenticate(&headers).await.unwrap_err();
         assert_eq!(err, AuthReject::InsufficientScope);
     }
+
+    #[tokio::test]
+    async fn bearer_disabled_and_forward_disabled_requires_bearer() {
+        let auth = AuthentikAuth::new(AuthentikConfig {
+            accept_bearer: false,
+            forward_auth: false,
+            ..cfg_forward()
+        })
+        .unwrap();
+        let err = auth.authenticate(&HeaderMap::new()).await.unwrap_err();
+        assert_eq!(err, AuthReject::MissingBearer);
+    }
+
+    /// Local JWKS HTTP mock + RS256 JWT covering Authentik JWT claim/group paths.
+    async fn spawn_jwks_server(
+        jwks_json: serde_json::Value,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::get, Json, Router};
+        use tokio::net::TcpListener;
+
+        let app = Router::new().route(
+            "/jwks",
+            get(move || {
+                let body = jwks_json.clone();
+                async move { Json(body) }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/jwks"), handle)
+    }
+
+    fn sign_jwt(
+        mgr: &crate::jwks::JwksManager,
+        claims: serde_json::Value,
+    ) -> String {
+        use jsonwebtoken::{encode, Algorithm, Header};
+        let cur = mgr.current.load();
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(cur.kid.clone());
+        encode(&header, &claims, &cur.encoding).unwrap()
+    }
+
+    #[tokio::test]
+    async fn jwt_bearer_maps_groups_and_merges_scopes() {
+        use crate::jwks::JwksManager;
+        use axum::http::header;
+
+        let mgr = JwksManager::new_with_fresh("ak-jwt").unwrap();
+        let jwks_body = serde_json::json!({ "keys": mgr.jwks() });
+        let (jwks_url, _server) = spawn_jwks_server(jwks_body).await;
+
+        let issuer = "https://auth.test/application/o/mcp/";
+        let audience = "https://mcp.test/mcp";
+        let mut group_scopes = BTreeMap::new();
+        group_scopes.insert("mcp-users".into(), "mcp:use".into());
+        group_scopes.insert("architect".into(), "upstream:architect_c4".into());
+
+        let auth = AuthentikAuth::new(AuthentikConfig {
+            issuer: issuer.into(),
+            jwks_url,
+            audiences: vec![audience.into()],
+            resource: audience.into(),
+            accept_bearer: true,
+            forward_auth: false,
+            groups_claim: "groups".into(),
+            group_scopes,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let now = Utc::now().timestamp();
+        let token = sign_jwt(
+            &mgr,
+            serde_json::json!({
+                "iss": issuer,
+                "aud": [audience, "extra-aud"],
+                "sub": "u1",
+                "preferred_username": "alice",
+                "client_id": "cursor",
+                "scope": "mcp:read",
+                "groups": ["mcp-users", "architect"],
+                "iat": now,
+                "exp": now + 3600,
+                "jti": "jti-1",
+            }),
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+        let id = auth.authenticate(&headers).await.unwrap();
+        assert_eq!(id.source, AuthSource::AuthentikJwt);
+        assert_eq!(id.subject, "alice");
+        assert_eq!(id.client_id, "cursor");
+        assert!(id.scope.contains("mcp:read"));
+        assert!(id.scope.contains("mcp:use"));
+        assert!(id.scope.contains("upstream:architect_c4"));
+        assert_eq!(id.audience, audience);
+    }
+
+    #[tokio::test]
+    async fn jwt_groups_from_string_claim_and_insufficient_scope() {
+        use crate::jwks::JwksManager;
+        use axum::http::header;
+
+        let mgr = JwksManager::new_with_fresh("ak-jwt2").unwrap();
+        let (jwks_url, _server) =
+            spawn_jwks_server(serde_json::json!({ "keys": mgr.jwks() })).await;
+        let issuer = "https://auth.test/application/o/mcp/";
+        let audience = "https://mcp.test/mcp";
+        let mut group_scopes = BTreeMap::new();
+        group_scopes.insert("mcp-users".into(), "mcp:use".into());
+
+        let auth = AuthentikAuth::new(AuthentikConfig {
+            issuer: issuer.into(),
+            jwks_url,
+            audiences: vec![audience.into()],
+            resource: audience.into(),
+            accept_bearer: true,
+            forward_auth: true,
+            groups_claim: "ak_groups".into(),
+            group_scopes,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let now = Utc::now().timestamp();
+        let good = sign_jwt(
+            &mgr,
+            serde_json::json!({
+                "iss": issuer,
+                "aud": audience,
+                "sub": "u2",
+                "ak_groups": "mcp-users|other",
+                "iat": now,
+                "exp": now + 3600,
+            }),
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {good}")).unwrap(),
+        );
+        let id = auth.authenticate(&headers).await.unwrap();
+        assert_eq!(id.scope, "mcp:use");
+        assert_eq!(id.subject, "u2");
+
+        let empty = sign_jwt(
+            &mgr,
+            serde_json::json!({
+                "iss": issuer,
+                "aud": audience,
+                "sub": "u3",
+                "groups": ["unrelated"],
+                "iat": now,
+                "exp": now + 3600,
+            }),
+        );
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {empty}")).unwrap(),
+        );
+        assert_eq!(
+            auth.authenticate(&headers).await.unwrap_err(),
+            AuthReject::InsufficientScope
+        );
+
+        let bad = sign_jwt(
+            &mgr,
+            serde_json::json!({
+                "iss": "https://evil.example/",
+                "aud": audience,
+                "sub": "u4",
+                "groups": ["mcp-users"],
+                "iat": now,
+                "exp": now + 3600,
+            }),
+        );
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {bad}")).unwrap(),
+        );
+        assert_eq!(
+            auth.authenticate(&headers).await.unwrap_err(),
+            AuthReject::InvalidToken
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_header_names_rejected_at_construct() {
+        let err = AuthentikAuth::new(AuthentikConfig {
+            username_header: "bad header".into(),
+            ..cfg_forward()
+        })
+        .err()
+        .expect("invalid header name must fail");
+        assert!(err.to_string().contains("username_header"));
+    }
 }

--- a/crates/vmcp-auth/src/providers/authentik.rs
+++ b/crates/vmcp-auth/src/providers/authentik.rs
@@ -1,5 +1,5 @@
-//! Authentik provider via [`async_oidc_jwt_validator`] (JWKS cache + OIDC checks)
-//! plus optional forward-auth headers from a trusted gateway.
+//! Authentik provider: remote JWKS (rustls `reqwest`) + optional forward-auth
+//! headers from a trusted gateway.
 //!
 //! Contract:
 //! 1. Trust gateway headers only when present — never invent anonymous / default role.
@@ -9,14 +9,15 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use async_oidc_jwt_validator::{Algorithm, OidcConfig, OidcValidator, Validation};
 use axum::http::{HeaderMap, HeaderName};
 use chrono::Utc;
+use jsonwebtoken::{Algorithm, Validation};
 use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::facade::{AuthFacade, AuthIdentity, AuthReject, AuthSource};
 use crate::groups::{scopes_from_groups, split_groups};
+use crate::remote_jwks::RemoteJwks;
 
 /// Configuration snapshot for Authentik-backed auth.
 #[derive(Debug, Clone)]
@@ -72,7 +73,7 @@ pub struct AuthentikAuth {
     groups_header: HeaderName,
     groups_claim: String,
     group_scopes: BTreeMap<String, String>,
-    validator: Arc<OidcValidator>,
+    jwks: Arc<RemoteJwks>,
 }
 
 impl AuthentikAuth {
@@ -81,16 +82,7 @@ impl AuthentikAuth {
             .map_err(|e| anyhow::anyhow!("invalid username_header: {e}"))?;
         let groups_header = HeaderName::from_bytes(cfg.groups_header.as_bytes())
             .map_err(|e| anyhow::anyhow!("invalid groups_header: {e}"))?;
-
-        // `client_id` in OidcConfig is the default `aud` for `validate()`;
-        // we always use `validate_custom` with resource audiences instead.
-        let primary_aud = cfg
-            .audiences
-            .first()
-            .cloned()
-            .unwrap_or_else(|| cfg.resource.clone());
-        let oidc = OidcConfig::new(cfg.issuer.clone(), primary_aud, cfg.jwks_url);
-        let validator = OidcValidator::new(oidc);
+        let jwks = RemoteJwks::new(cfg.jwks_url)?;
 
         Ok(Self {
             issuer: cfg.issuer,
@@ -102,7 +94,7 @@ impl AuthentikAuth {
             groups_header,
             groups_claim: cfg.groups_claim,
             group_scopes: cfg.group_scopes,
-            validator: Arc::new(validator),
+            jwks: Arc::new(jwks),
         })
     }
 
@@ -169,14 +161,14 @@ impl AuthentikAuth {
         validation.validate_aud = true;
         validation.validate_exp = true;
 
-        let claims: AuthentikClaims = self
-            .validator
-            .validate_custom(token, &validation)
-            .await
-            .map_err(|e| {
-                tracing::debug!(error = %e, "authentik jwt rejected");
-                AuthReject::InvalidToken
-            })?;
+        let claims: AuthentikClaims =
+            self.jwks
+                .decode_claims(token, &validation)
+                .await
+                .map_err(|e| {
+                    tracing::debug!(error = %e, "authentik jwt rejected");
+                    AuthReject::InvalidToken
+                })?;
 
         let groups = self.extract_groups(&claims);
         let mut scope = claims.scope.unwrap_or_default();

--- a/crates/vmcp-auth/src/providers/local.rs
+++ b/crates/vmcp-auth/src/providers/local.rs
@@ -1,0 +1,80 @@
+//! Local OAuth AS/RS provider (vmcp-issued JWT + static `vmcp_` tokens).
+
+use axum::http::HeaderMap;
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::facade::{AuthIdentity, AuthReject, AuthSource};
+use crate::state::AuthState;
+use crate::static_tokens::{self, TokenInfo};
+use crate::tokens::verify_access_token;
+
+/// Local provider: static tokens + JWTs signed by this process's JWKS.
+#[derive(Clone)]
+pub struct LocalAuth {
+    pub state: AuthState,
+}
+
+impl LocalAuth {
+    pub fn new(state: AuthState) -> Self {
+        Self { state }
+    }
+
+    pub fn authenticate(&self, headers: &HeaderMap) -> Result<AuthIdentity, AuthReject> {
+        let token = match AuthFacadeBearer::extract(headers)? {
+            Some(t) => t,
+            None => return Err(AuthReject::MissingBearer),
+        };
+
+        if let Some(store) = &self.state.token_store {
+            if token.starts_with(static_tokens::TOKEN_PREFIX) {
+                return match store.lookup(token) {
+                    Some(info) => Ok(synth_static(&self.state, &info)),
+                    None => Err(AuthReject::InvalidToken),
+                };
+            }
+        }
+
+        let audiences = self.state.audience_refs();
+        match verify_access_token(&self.state.jwks, token, &self.state.issuer, &audiences) {
+            Ok(claims) => Ok(AuthIdentity {
+                subject: claims.sub.clone(),
+                client_id: claims.client_id.clone(),
+                scope: claims.scope.clone(),
+                groups: Vec::new(),
+                issuer: claims.iss,
+                audience: claims.aud,
+                iat: claims.iat,
+                exp: claims.exp,
+                jti: claims.jti,
+                source: AuthSource::LocalJwt,
+            }),
+            Err(_) => Err(AuthReject::InvalidToken),
+        }
+    }
+}
+
+/// Tiny helper so `LocalAuth` does not depend on the facade enum for Bearer parse.
+struct AuthFacadeBearer;
+impl AuthFacadeBearer {
+    fn extract(headers: &HeaderMap) -> Result<Option<&str>, AuthReject> {
+        crate::facade::AuthFacade::bearer_token(headers)
+    }
+}
+
+fn synth_static(state: &AuthState, info: &TokenInfo) -> AuthIdentity {
+    let now = Utc::now().timestamp();
+    let exp = now + 100 * 365 * 24 * 3600;
+    AuthIdentity {
+        subject: info.client_id.clone(),
+        client_id: info.client_id.clone(),
+        scope: info.scope.clone(),
+        groups: Vec::new(),
+        issuer: state.issuer.clone(),
+        audience: state.resource_audience.clone(),
+        iat: now,
+        exp,
+        jti: Uuid::new_v4().to_string(),
+        source: AuthSource::StaticToken,
+    }
+}

--- a/crates/vmcp-auth/src/providers/mod.rs
+++ b/crates/vmcp-auth/src/providers/mod.rs
@@ -1,0 +1,4 @@
+//! Concrete auth providers behind [`crate::facade::AuthFacade`].
+
+pub mod authentik;
+pub mod local;

--- a/crates/vmcp-auth/src/remote_jwks.rs
+++ b/crates/vmcp-auth/src/remote_jwks.rs
@@ -1,0 +1,217 @@
+//! Remote JWKS fetch + `kid` cache over rustls-backed `reqwest`.
+//!
+//! Replaces `async-oidc-jwt-validator`, which pulled OpenSSL via
+//! `reqwest` default `native-tls`. Signature verify stays in `jsonwebtoken`
+//! (`ring`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use jsonwebtoken::jwk::{Jwk, JwkSet};
+use jsonwebtoken::{decode, decode_header, DecodingKey, Validation};
+use serde::de::DeserializeOwned;
+use tokio::sync::RwLock;
+
+/// HTTPS JWKS client with an in-memory `kid → Jwk` cache.
+///
+/// Cache miss for a `kid` triggers a refresh; unknown `kid` after refresh
+/// rejects the token.
+#[derive(Clone)]
+pub struct RemoteJwks {
+    url: String,
+    http: reqwest::Client,
+    cache: Arc<RwLock<HashMap<String, Jwk>>>,
+}
+
+impl RemoteJwks {
+    pub fn new(jwks_url: impl Into<String>) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(5))
+            .user_agent(concat!("vmcp/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .context("build rustls reqwest client for JWKS")?;
+        Ok(Self {
+            url: jwks_url.into(),
+            http,
+            cache: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    async fn fetch(&self) -> Result<JwkSet> {
+        let resp = self
+            .http
+            .get(&self.url)
+            .send()
+            .await
+            .with_context(|| format!("GET {}", self.url))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(anyhow!("JWKS GET {} → HTTP {status}", self.url));
+        }
+        resp.json::<JwkSet>()
+            .await
+            .with_context(|| format!("decode JWKS JSON from {}", self.url))
+    }
+
+    async fn refresh(&self) -> Result<()> {
+        let set = self.fetch().await?;
+        let mut map = HashMap::with_capacity(set.keys.len());
+        for jwk in set.keys {
+            if let Some(kid) = jwk.common.key_id.clone() {
+                map.insert(kid, jwk);
+            }
+        }
+        let n = map.len();
+        *self.cache.write().await = map;
+        tracing::debug!(url = %self.url, keys = n, "refreshed remote JWKS cache");
+        Ok(())
+    }
+
+    async fn key_for(&self, kid: &str) -> Result<Jwk> {
+        {
+            let cache = self.cache.read().await;
+            if let Some(jwk) = cache.get(kid) {
+                return Ok(jwk.clone());
+            }
+        }
+        self.refresh().await?;
+        self.cache
+            .read()
+            .await
+            .get(kid)
+            .cloned()
+            .ok_or_else(|| anyhow!("JWKS has no key with kid={kid}"))
+    }
+
+    /// Decode `token` claims after JWKS lookup by `kid`.
+    pub async fn decode_claims<T: DeserializeOwned>(
+        &self,
+        token: &str,
+        validation: &Validation,
+    ) -> Result<T> {
+        let header = decode_header(token).context("JWT header")?;
+        let kid = header
+            .kid
+            .ok_or_else(|| anyhow!("JWT missing kid header"))?;
+        let jwk = self.key_for(&kid).await?;
+        let key = DecodingKey::from_jwk(&jwk).context("DecodingKey::from_jwk")?;
+        let data = decode::<T>(token, &key, validation).context("JWT signature/claims")?;
+        Ok(data.claims)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jwks::JwksManager;
+    use axum::{routing::get, Json, Router};
+    use chrono::Utc;
+    use jsonwebtoken::{encode, Algorithm, Header};
+    use tokio::net::TcpListener;
+
+    struct JwksServer {
+        url: String,
+        handle: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for JwksServer {
+        fn drop(&mut self) {
+            self.handle.abort();
+        }
+    }
+
+    async fn spawn_jwks(body: serde_json::Value) -> JwksServer {
+        let app = Router::new().route(
+            "/jwks",
+            get(move || {
+                let body = body.clone();
+                async move { Json(body) }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        JwksServer {
+            url: format!("http://{addr}/jwks"),
+            handle,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetches_caches_and_verifies_rs256() {
+        let mgr = JwksManager::new_with_fresh("remote").unwrap();
+        let server = spawn_jwks(serde_json::json!({ "keys": mgr.jwks() })).await;
+        let remote = RemoteJwks::new(server.url.clone()).unwrap();
+
+        let now = Utc::now().timestamp();
+        let cur = mgr.current.load();
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(cur.kid.clone());
+        let token = encode(
+            &header,
+            &serde_json::json!({
+                "iss": "https://iss.test/",
+                "aud": "https://mcp.test/mcp",
+                "sub": "alice",
+                "iat": now,
+                "exp": now + 3600,
+            }),
+            &cur.encoding,
+        )
+        .unwrap();
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&["https://iss.test/"]);
+        validation.set_audience(&["https://mcp.test/mcp"]);
+
+        #[derive(Debug, serde::Deserialize)]
+        struct C {
+            sub: String,
+        }
+        let claims: C = remote.decode_claims(&token, &validation).await.unwrap();
+        assert_eq!(claims.sub, "alice");
+
+        // Second call hits cache (no error even if we don't assert network).
+        let _: C = remote.decode_claims(&token, &validation).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_kid_after_refresh_is_error() {
+        let mgr = JwksManager::new_with_fresh("remote2").unwrap();
+        let server = spawn_jwks(serde_json::json!({ "keys": mgr.jwks() })).await;
+        let remote = RemoteJwks::new(server.url.clone()).unwrap();
+
+        let now = Utc::now().timestamp();
+        let cur = mgr.current.load();
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("not-in-jwks".into());
+        // Sign with real key but advertise a foreign kid → cache miss + refresh miss.
+        let token = encode(
+            &header,
+            &serde_json::json!({
+                "iss": "https://iss.test/",
+                "aud": "https://mcp.test/mcp",
+                "sub": "x",
+                "exp": now + 3600,
+            }),
+            &cur.encoding,
+        )
+        .unwrap();
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&["https://iss.test/"]);
+        validation.set_audience(&["https://mcp.test/mcp"]);
+        validation.validate_exp = true;
+
+        let err = remote
+            .decode_claims::<serde_json::Value>(&token, &validation)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("kid"), "unexpected error: {err:#}");
+    }
+}

--- a/crates/vmcp-auth/src/router.rs
+++ b/crates/vmcp-auth/src/router.rs
@@ -21,6 +21,77 @@ use crate::state::AuthState;
 use crate::tokens::issue_access_token;
 use crate::types::*;
 
+/// Protected-resource metadata only (Authentik / external AS mode).
+///
+/// MCP clients discover Authentik via `authorization_servers`; vmcp does not
+/// mount local `/authorize`, `/token`, or DCR in this mode.
+pub fn build_external_rs_router(
+    resource: String,
+    authorization_servers: Vec<String>,
+    resource_audiences: Vec<String>,
+) -> Router {
+    let state = ExternalRsState {
+        resource: resource.clone(),
+        authorization_servers,
+        resource_audiences,
+    };
+    let mut router = Router::new().route(
+        "/.well-known/oauth-protected-resource",
+        get(external_rs_metadata),
+    );
+    for aud in &state.resource_audiences {
+        if let Ok(url) = url::Url::parse(aud) {
+            let path = url.path();
+            if path.len() > 1 {
+                let route = format!("/.well-known/oauth-protected-resource{path}");
+                router = router.route(&route, get(external_rs_metadata_scoped));
+            }
+        }
+    }
+    router.with_state(state)
+}
+
+#[derive(Clone)]
+struct ExternalRsState {
+    resource: String,
+    authorization_servers: Vec<String>,
+    resource_audiences: Vec<String>,
+}
+
+async fn external_rs_metadata(State(s): State<ExternalRsState>) -> Json<ProtectedResourceMetadata> {
+    Json(ProtectedResourceMetadata {
+        resource: s.resource.clone(),
+        authorization_servers: s.authorization_servers.clone(),
+        bearer_methods_supported: vec!["header"],
+        resource_documentation: s.authorization_servers.first().cloned(),
+    })
+}
+
+async fn external_rs_metadata_scoped(
+    State(s): State<ExternalRsState>,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+) -> Result<Json<ProtectedResourceMetadata>, StatusCode> {
+    const PREFIX: &str = "/.well-known/oauth-protected-resource";
+    let suffix = uri.path().strip_prefix(PREFIX).unwrap_or("");
+    if suffix.is_empty() || !suffix.starts_with('/') {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let matched = s.resource_audiences.iter().find(|aud| {
+        url::Url::parse(aud)
+            .ok()
+            .is_some_and(|u| u.path() == suffix)
+    });
+    match matched {
+        Some(resource) => Ok(Json(ProtectedResourceMetadata {
+            resource: resource.clone(),
+            authorization_servers: s.authorization_servers.clone(),
+            bearer_methods_supported: vec!["header"],
+            resource_documentation: s.authorization_servers.first().cloned(),
+        })),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
 /// Mount all OAuth-facing routes. None require authentication themselves —
 /// authentication is for the MCP endpoint, layered separately by the bin
 /// crate.

--- a/crates/vmcp-auth/src/router.rs
+++ b/crates/vmcp-auth/src/router.rs
@@ -927,7 +927,9 @@ mod tests {
         )
         .await;
         assert_eq!(page.status(), StatusCode::OK);
-        let html = axum::body::to_bytes(page.into_body(), 1 << 16).await.unwrap();
+        let html = axum::body::to_bytes(page.into_body(), 1 << 16)
+            .await
+            .unwrap();
         assert!(String::from_utf8_lossy(&html).contains("vmcp consent"));
 
         // Wrong password leaves session intact.
@@ -1034,7 +1036,13 @@ mod tests {
         let master = "tok-master";
         let hash = crate::password::hash_password(master).unwrap();
         let jwks = crate::jwks::JwksManager::new_with_fresh("tok").unwrap();
-        let state = AuthState::new(jwks, "https://iss.example", "https://iss.example/mcp", 3600, hash);
+        let state = AuthState::new(
+            jwks,
+            "https://iss.example",
+            "https://iss.example/mcp",
+            3600,
+            hash,
+        );
 
         let reg = post_register(
             state.clone(),
@@ -1047,7 +1055,8 @@ mod tests {
         let reg_body = axum::body::to_bytes(reg.into_body(), 1 << 16)
             .await
             .unwrap();
-        let client_id = serde_json::from_slice::<serde_json::Value>(&reg_body).unwrap()["client_id"]
+        let client_id = serde_json::from_slice::<serde_json::Value>(&reg_body).unwrap()
+            ["client_id"]
             .as_str()
             .unwrap()
             .to_string();

--- a/crates/vmcp-auth/src/router.rs
+++ b/crates/vmcp-auth/src/router.rs
@@ -816,4 +816,467 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
+
+    async fn oneshot(
+        state: AuthState,
+        req: axum::http::Request<axum::body::Body>,
+    ) -> axum::http::Response<axum::body::Body> {
+        use tower::ServiceExt;
+        build_router(state).oneshot(req).await.unwrap()
+    }
+
+    fn pkce_pair() -> (String, String) {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string();
+        let challenge = pkce_s256(&verifier);
+        (verifier, challenge)
+    }
+
+    #[tokio::test]
+    async fn oauth_metadata_jwks_and_full_code_flow() {
+        use axum::body::Body;
+
+        let master = "oauth-master-secret";
+        let hash = crate::password::hash_password(master).unwrap();
+        let jwks = crate::jwks::JwksManager::new_with_fresh("oauth-flow").unwrap();
+        let state = AuthState::new(
+            jwks,
+            "https://iss.example",
+            "https://iss.example/mcp",
+            3600,
+            hash,
+        )
+        .with_extra_resource_audiences(vec!["https://iss.example/mcp-proxy".into()]);
+
+        // Well-known + JWKS.
+        for uri in [
+            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-protected-resource/mcp",
+            "/.well-known/oauth-protected-resource/mcp-proxy",
+            "/.well-known/jwks.json",
+        ] {
+            let resp = oneshot(
+                state.clone(),
+                axum::http::Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(resp.status(), StatusCode::OK, "GET {uri}");
+        }
+        let miss = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .uri("/.well-known/oauth-protected-resource/unknown")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(miss.status(), StatusCode::NOT_FOUND);
+
+        // DCR register.
+        let reg = post_register(
+            state.clone(),
+            serde_json::json!({
+                "client_name": "Flow Client!!",
+                "redirect_uris": ["http://127.0.0.1/cb?x=1"],
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"]
+            }),
+        )
+        .await;
+        assert_eq!(reg.status(), StatusCode::OK);
+        let reg_body = axum::body::to_bytes(reg.into_body(), 1 << 16)
+            .await
+            .unwrap();
+        let reg_v: serde_json::Value = serde_json::from_slice(&reg_body).unwrap();
+        let client_id = reg_v["client_id"].as_str().unwrap().to_string();
+
+        let (verifier, challenge) = pkce_pair();
+        let auth_uri = format!(
+            "/authorize?client_id={client_id}&redirect_uri={}&response_type=code&code_challenge={challenge}&code_challenge_method=S256&state=xyz&scope=mcp:use&resource=https://iss.example/mcp",
+            urlencoding_path("http://127.0.0.1/cb?x=1")
+        );
+        let auth_resp = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .uri(&auth_uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(auth_resp.status(), StatusCode::SEE_OTHER);
+        let loc = auth_resp
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(loc.contains("/consent?cs="));
+        let cs = loc.split("cs=").nth(1).unwrap().to_string();
+
+        // Consent page HTML.
+        let page = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .uri(format!("/consent?cs={cs}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(page.status(), StatusCode::OK);
+        let html = axum::body::to_bytes(page.into_body(), 1 << 16).await.unwrap();
+        assert!(String::from_utf8_lossy(&html).contains("vmcp consent"));
+
+        // Wrong password leaves session intact.
+        let bad = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/consent")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!("cs={cs}&password=wrong")))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(bad.status(), StatusCode::FORBIDDEN);
+
+        // Grant.
+        let grant = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/consent")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!("cs={cs}&password={master}")))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(grant.status(), StatusCode::SEE_OTHER);
+        let cb = grant
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(cb.contains("code="));
+        assert!(cb.contains("state=xyz"));
+        let code = cb
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap()
+            .to_string();
+
+        let token_body = format!(
+            "grant_type=authorization_code&code={code}&code_verifier={verifier}&client_id={client_id}&redirect_uri={}&resource=https://iss.example/mcp",
+            urlencoding_path("http://127.0.0.1/cb?x=1")
+        );
+        let token_resp = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/token")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(token_body))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(token_resp.status(), StatusCode::OK);
+        let tb = axum::body::to_bytes(token_resp.into_body(), 1 << 16)
+            .await
+            .unwrap();
+        let tv: serde_json::Value = serde_json::from_slice(&tb).unwrap();
+        assert_eq!(tv["token_type"], "Bearer");
+        assert!(tv["access_token"].as_str().unwrap().len() > 20);
+
+        // Authorize rejects bad response_type / unknown client.
+        let bad_rt = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .uri(format!(
+                    "/authorize?client_id={client_id}&redirect_uri={}&response_type=token&code_challenge={challenge}&code_challenge_method=S256",
+                    urlencoding_path("http://127.0.0.1/cb?x=1")
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(bad_rt.status(), StatusCode::BAD_REQUEST);
+
+        let unk = oneshot(
+            state,
+            axum::http::Request::builder()
+                .uri(format!(
+                    "/authorize?client_id=nope&redirect_uri={}&response_type=code&code_challenge={challenge}&code_challenge_method=S256",
+                    urlencoding_path("http://127.0.0.1/cb?x=1")
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(unk.status(), StatusCode::BAD_REQUEST);
+    }
+
+    fn urlencoding_path(s: &str) -> String {
+        utf8_percent_encode(s, NON_ALPHANUMERIC).to_string()
+    }
+
+    #[tokio::test]
+    async fn token_endpoint_rejects_bad_grant_and_pkce() {
+        use axum::body::Body;
+
+        let master = "tok-master";
+        let hash = crate::password::hash_password(master).unwrap();
+        let jwks = crate::jwks::JwksManager::new_with_fresh("tok").unwrap();
+        let state = AuthState::new(jwks, "https://iss.example", "https://iss.example/mcp", 3600, hash);
+
+        let reg = post_register(
+            state.clone(),
+            serde_json::json!({
+                "client_name": "t",
+                "redirect_uris": ["http://127.0.0.1/cb"]
+            }),
+        )
+        .await;
+        let reg_body = axum::body::to_bytes(reg.into_body(), 1 << 16)
+            .await
+            .unwrap();
+        let client_id = serde_json::from_slice::<serde_json::Value>(&reg_body).unwrap()["client_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let (verifier, challenge) = pkce_pair();
+
+        let auth = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .uri(format!(
+                    "/authorize?client_id={client_id}&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcb&response_type=code&code_challenge={challenge}&code_challenge_method=S256"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        let cs = auth
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .split("cs=")
+            .nth(1)
+            .unwrap()
+            .to_string();
+        let grant = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/consent")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!("cs={cs}&password={master}")))
+                .unwrap(),
+        )
+        .await;
+        let code = grant
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap()
+            .to_string();
+
+        let bad_grant = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/token")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("grant_type=client_credentials"))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(bad_grant.status(), StatusCode::BAD_REQUEST);
+
+        let bad_pkce = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/token")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "grant_type=authorization_code&code={code}&code_verifier=wrong-verifier-value-xx&client_id={client_id}&redirect_uri=http://127.0.0.1/cb"
+                )))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(bad_pkce.status(), StatusCode::BAD_REQUEST);
+
+        // Re-mint a fresh code for success with bare-origin resource.
+        let auth2 = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .uri(format!(
+                    "/authorize?client_id={client_id}&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcb&response_type=code&code_challenge={challenge}&code_challenge_method=S256"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        let cs2 = auth2
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .split("cs=")
+            .nth(1)
+            .unwrap()
+            .to_string();
+        let grant2 = oneshot(
+            state.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/consent")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!("cs={cs2}&password={master}")))
+                .unwrap(),
+        )
+        .await;
+        let code2 = grant2
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap()
+            .to_string();
+        let ok = oneshot(
+            state,
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/token")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "grant_type=authorization_code&code={code2}&code_verifier={verifier}&client_id={client_id}&redirect_uri=http://127.0.0.1/cb&resource=https://iss.example"
+                )))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(ok.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn external_rs_router_serves_prm_and_scoped_paths() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let app = build_external_rs_router(
+            "https://mcp.example/mcp".into(),
+            vec!["https://auth.example/application/o/mcp/".into()],
+            vec![
+                "https://mcp.example/mcp".into(),
+                "https://mcp.example/mcp-proxy".into(),
+            ],
+        );
+
+        let bare = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/.well-known/oauth-protected-resource")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bare.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(bare.into_body(), 1 << 16)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["resource"], "https://mcp.example/mcp");
+        assert_eq!(
+            v["authorization_servers"][0],
+            "https://auth.example/application/o/mcp/"
+        );
+
+        for path in ["/mcp", "/mcp-proxy"] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    axum::http::Request::builder()
+                        .uri(format!("/.well-known/oauth-protected-resource{path}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "path {path}");
+            let b = axum::body::to_bytes(resp.into_body(), 1 << 16)
+                .await
+                .unwrap();
+            let j: serde_json::Value = serde_json::from_slice(&b).unwrap();
+            assert_eq!(j["resource"], format!("https://mcp.example{path}"));
+        }
+
+        let miss = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/.well-known/oauth-protected-resource/nope")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(miss.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn dcr_empty_redirect_uris_rejected_and_persist_path() {
+        use crate::client_store::ClientStore;
+        use std::sync::Arc;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("clients.db");
+        let store = Arc::new(ClientStore::open(&db).unwrap());
+        let state = test_auth_state().with_client_store(store).unwrap();
+
+        let empty = post_register(
+            state.clone(),
+            serde_json::json!({
+                "client_name": "x",
+                "redirect_uris": []
+            }),
+        )
+        .await;
+        assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+
+        let ok = post_register(
+            state,
+            serde_json::json!({
+                "client_name": "persisted",
+                "redirect_uris": ["http://127.0.0.1/cb"]
+            }),
+        )
+        .await;
+        assert_eq!(ok.status(), StatusCode::OK);
+    }
 }

--- a/crates/vmcp-auth/src/router.rs
+++ b/crates/vmcp-auth/src/router.rs
@@ -515,8 +515,10 @@ async fn token_endpoint(
         .ok_or_else(|| AuthError::BadRequest("invalid code".into()))?
         .1;
 
-    // TTL: 10 minutes.
-    if (Utc::now() - rec.issued_at).num_seconds() > 600 {
+    // TTL: same window as [`crate::state::AUTH_EPHEMERAL_MAX_AGE`] / background GC.
+    if (Utc::now() - rec.issued_at).num_seconds()
+        > crate::state::AUTH_EPHEMERAL_MAX_AGE.as_secs() as i64
+    {
         return Err(AuthError::BadRequest("expired code".into()));
     }
     if rec.client_id != client_id {

--- a/crates/vmcp-auth/src/state.rs
+++ b/crates/vmcp-auth/src/state.rs
@@ -393,4 +393,68 @@ mod tests {
         // Prefix-host attack must fail (G27).
         assert!(!locked.redirect_uri_allowed("http://127.0.0.1.evil.example/cb"));
     }
+
+    #[test]
+    fn dcr_allowlist_path_port_and_unparseable_entries() {
+        let with_path = DcrPolicy {
+            enabled: true,
+            max_clients: 0,
+            redirect_uri_allowlist: vec![
+                "https://app.example/callback".into(),
+                "http://127.0.0.1:8080".into(),
+                "".into(),
+                "custom-scheme:prefix".into(),
+            ],
+        };
+        assert!(with_path.redirect_uri_allowed("https://app.example/callback"));
+        assert!(with_path.redirect_uri_allowed("https://app.example/callback/extra"));
+        assert!(!with_path.redirect_uri_allowed("https://app.example/other"));
+        assert!(with_path.redirect_uri_allowed("http://127.0.0.1:8080/x"));
+        assert!(!with_path.redirect_uri_allowed("http://127.0.0.1:9999/x"));
+        // Unparseable allow entry → literal prefix match.
+        assert!(with_path.redirect_uri_allowed("custom-scheme:prefix/more"));
+        assert!(!with_path.redirect_uri_allowed("://broken"));
+    }
+
+    #[test]
+    fn gc_and_audience_helpers() {
+        use crate::types::{AuthCodeRecord, ConsentSession};
+
+        let jwks = JwksManager::new_with_fresh("gc").unwrap();
+        let state = AuthState::new(jwks, "https://iss", "https://iss/mcp", 3600, "hash")
+            .with_extra_resource_audiences(vec!["https://iss/mcp".into(), "https://iss/mcp-proxy".into()]);
+        assert_eq!(state.audience_refs().len(), 2);
+
+        let old = Utc::now() - chrono::Duration::hours(2);
+        state.codes.insert(
+            "old".into(),
+            AuthCodeRecord {
+                code: "old".into(),
+                client_id: "c".into(),
+                redirect_uri: "http://127.0.0.1/cb".into(),
+                code_challenge: "x".into(),
+                code_challenge_method: "S256".into(),
+                scope: "mcp:use".into(),
+                resource: None,
+                issued_at: old,
+            },
+        );
+        state.consents.insert(
+            "cs".into(),
+            ConsentSession {
+                id: "cs".into(),
+                client_id: "c".into(),
+                redirect_uri: "http://127.0.0.1/cb".into(),
+                state: None,
+                scope: "mcp:use".into(),
+                code_challenge: "x".into(),
+                code_challenge_method: "S256".into(),
+                resource: None,
+                created_at: old,
+            },
+        );
+        state.gc(Duration::from_secs(60));
+        assert!(state.codes.is_empty());
+        assert!(state.consents.is_empty());
+    }
 }

--- a/crates/vmcp-auth/src/state.rs
+++ b/crates/vmcp-auth/src/state.rs
@@ -422,7 +422,10 @@ mod tests {
 
         let jwks = JwksManager::new_with_fresh("gc").unwrap();
         let state = AuthState::new(jwks, "https://iss", "https://iss/mcp", 3600, "hash")
-            .with_extra_resource_audiences(vec!["https://iss/mcp".into(), "https://iss/mcp-proxy".into()]);
+            .with_extra_resource_audiences(vec![
+                "https://iss/mcp".into(),
+                "https://iss/mcp-proxy".into(),
+            ]);
         assert_eq!(state.audience_refs().len(), 2);
 
         let old = Utc::now() - chrono::Duration::hours(2);

--- a/crates/vmcp-auth/src/state.rs
+++ b/crates/vmcp-auth/src/state.rs
@@ -59,6 +59,13 @@ pub struct AuthState {
     pub dcr_register_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
+/// Max age for ephemeral OAuth flow state (`codes` + `consents`).
+///
+/// Matches the authorization-code TTL enforced at `/token` (10 minutes).
+/// Abandoned `/authorize` → consent sessions and unused codes must be purged
+/// on this cadence or the DashMaps grow without bound (resource leak).
+pub const AUTH_EPHEMERAL_MAX_AGE: Duration = Duration::from_secs(600);
+
 /// Limits for `POST /register`. Defaults match historical open registration.
 #[derive(Debug, Clone)]
 pub struct DcrPolicy {
@@ -208,10 +215,27 @@ impl AuthState {
     }
 
     /// Purge codes and consent sessions older than `max_age`.
-    pub fn gc(&self, max_age: Duration) {
+    ///
+    /// Returns how many entries were removed (codes + consents). Call from a
+    /// background task — see `AUTH_EPHEMERAL_MAX_AGE`.
+    pub fn gc(&self, max_age: Duration) -> usize {
         let cutoff = chrono::Utc::now() - chrono::Duration::from_std(max_age).unwrap();
-        self.codes.retain(|_, v| v.issued_at > cutoff);
-        self.consents.retain(|_, v| v.created_at > cutoff);
+        let mut removed = 0usize;
+        self.codes.retain(|_, v| {
+            let keep = v.issued_at > cutoff;
+            if !keep {
+                removed += 1;
+            }
+            keep
+        });
+        self.consents.retain(|_, v| {
+            let keep = v.created_at > cutoff;
+            if !keep {
+                removed += 1;
+            }
+            keep
+        });
+        removed
     }
 
     /// Snapshot of all currently-registered OAuth dynamic clients.
@@ -456,8 +480,32 @@ mod tests {
                 created_at: old,
             },
         );
-        state.gc(Duration::from_secs(60));
+        let removed = state.gc(Duration::from_secs(60));
+        assert_eq!(removed, 2);
         assert!(state.codes.is_empty());
         assert!(state.consents.is_empty());
+
+        // Fresh entries survive a short max_age.
+        let now = Utc::now();
+        state.codes.insert(
+            "fresh".into(),
+            AuthCodeRecord {
+                code: "fresh".into(),
+                client_id: "c".into(),
+                redirect_uri: "http://127.0.0.1/cb".into(),
+                code_challenge: "x".into(),
+                code_challenge_method: "S256".into(),
+                scope: "mcp:use".into(),
+                resource: None,
+                issued_at: now,
+            },
+        );
+        assert_eq!(state.gc(AUTH_EPHEMERAL_MAX_AGE), 0);
+        assert!(state.codes.contains_key("fresh"));
+    }
+
+    #[test]
+    fn ephemeral_max_age_matches_token_code_ttl() {
+        assert_eq!(AUTH_EPHEMERAL_MAX_AGE.as_secs(), 600);
     }
 }

--- a/crates/vmcp-auth/src/types.rs
+++ b/crates/vmcp-auth/src/types.rs
@@ -221,3 +221,46 @@ pub struct JwkPublicKey {
 pub fn get_param<'a>(map: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
     map.get(key).map(|s| s.as_str())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_collapses_punctuation_and_length() {
+        assert_eq!(slugify_client_base(None), "client");
+        assert_eq!(slugify_client_base(Some("!!!")), "client");
+        assert_eq!(slugify_client_base(Some("Flow Client!!")), "flow-client");
+        let long = "A".repeat(60);
+        let slug = slugify_client_base(Some(&long));
+        assert!(slug.len() <= 48);
+        assert!(!slug.ends_with('-'));
+        // truncate that leaves only separators → fallback
+        assert_eq!(slugify_client_base(Some(&"-".repeat(60)),), "client");
+    }
+
+    #[test]
+    fn next_unique_name_increments() {
+        let mut set = std::collections::HashSet::new();
+        set.insert("cursor".into());
+        assert_eq!(next_unique_name(&set, "cursor"), "cursor-2");
+        set.insert("cursor-2".into());
+        assert_eq!(next_unique_name(&set, "cursor"), "cursor-3");
+        assert_eq!(next_unique_name(&set, "fresh"), "fresh");
+    }
+
+    #[test]
+    fn get_param_reads_map() {
+        let mut m = BTreeMap::new();
+        m.insert("a".into(), "1".into());
+        assert_eq!(get_param(&m, "a"), Some("1"));
+        assert_eq!(get_param(&m, "b"), None);
+    }
+
+    #[test]
+    fn display_name_validation() {
+        assert!(valid_client_display_name("cursor_1"));
+        assert!(!valid_client_display_name(""));
+        assert!(!valid_client_display_name("Bad Name"));
+    }
+}

--- a/crates/vmcp-config/src/lib.rs
+++ b/crates/vmcp-config/src/lib.rs
@@ -269,6 +269,128 @@ impl Default for UpstreamConfig {
     }
 }
 
+/// Which auth backend the facade mounts.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthProviderKind {
+    /// Built-in OAuth 2.1 AS + RS (DCR, PKCE, local JWKS, master-password consent).
+    #[default]
+    Local,
+    /// External Authentik IdP: Bearer JWT + optional forward-auth headers.
+    Authentik,
+}
+
+/// How `/admin` authenticates operators.
+///
+/// Independent of the MCP facade (`provider`): admin may be open, HTTP Basic,
+/// or Authentik forward-auth headers.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AdminAuthMode {
+    /// No auth on `/admin` (local/dev only).
+    None,
+    /// HTTP Basic (`user:password`) against `master_password_argon2`.
+    #[default]
+    Basic,
+    /// Trust gateway `X-authentik-*` headers (exact group membership).
+    Authentik,
+}
+
+/// Settings for the `/admin` SPA auth gate (`[auth.admin]`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AdminAuthSettings {
+    /// `none` | `basic` (default) | `authentik`.
+    #[serde(default)]
+    pub mode: AdminAuthMode,
+    /// Exact Authentik groups that may open `/admin` when `mode = authentik`.
+    /// Matching uses delimiter-split + exact equality (never substring).
+    #[serde(default)]
+    pub required_groups: Vec<String>,
+    /// Override username header (default: `[auth.authentik].username_header`).
+    #[serde(default)]
+    pub username_header: Option<String>,
+    /// Override groups header (default: `[auth.authentik].groups_header`).
+    #[serde(default)]
+    pub groups_header: Option<String>,
+}
+
+impl Default for AdminAuthSettings {
+    fn default() -> Self {
+        Self {
+            mode: AdminAuthMode::Basic,
+            required_groups: Vec::new(),
+            username_header: None,
+            groups_header: None,
+        }
+    }
+}
+
+/// Authentik-specific settings (`[auth.authentik]`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthentikSettings {
+    /// OIDC issuer URL (with trailing slash), e.g.
+    /// `https://auth.example.com/application/o/mcp-internal/`.
+    #[serde(default)]
+    pub issuer: String,
+    /// JWKS URL for signature verification.
+    #[serde(default)]
+    pub jwks_url: String,
+    /// Accepted JWT `aud` values (resource indicators). Empty → derived from
+    /// `public_base_url` + mcp/proxy paths at boot.
+    #[serde(default)]
+    pub audiences: Vec<String>,
+    /// Accept `Authorization: Bearer` JWTs from Authentik (MCP clients).
+    #[serde(default = "AuthentikSettings::default_true")]
+    pub accept_bearer: bool,
+    /// Accept `X-authentik-*` headers from a trusted forward-auth gateway.
+    #[serde(default = "AuthentikSettings::default_true")]
+    pub forward_auth: bool,
+    /// Username header (default `x-authentik-username`).
+    #[serde(default = "AuthentikSettings::default_username_header")]
+    pub username_header: String,
+    /// Groups header (default `x-authentik-groups`).
+    #[serde(default = "AuthentikSettings::default_groups_header")]
+    pub groups_header: String,
+    /// JWT claim carrying groups (default `groups`).
+    #[serde(default = "AuthentikSettings::default_groups_claim")]
+    pub groups_claim: String,
+    /// Exact Authentik group → space-separated MCP scopes.
+    /// Matching is exact after delimiter split (`|`, `,`, `;`, space).
+    #[serde(default)]
+    pub group_scopes: std::collections::BTreeMap<String, String>,
+}
+
+impl AuthentikSettings {
+    fn default_true() -> bool {
+        true
+    }
+    fn default_username_header() -> String {
+        "x-authentik-username".into()
+    }
+    fn default_groups_header() -> String {
+        "x-authentik-groups".into()
+    }
+    fn default_groups_claim() -> String {
+        "groups".into()
+    }
+}
+
+impl Default for AuthentikSettings {
+    fn default() -> Self {
+        Self {
+            issuer: String::new(),
+            jwks_url: String::new(),
+            audiences: Vec::new(),
+            accept_bearer: true,
+            forward_auth: true,
+            username_header: Self::default_username_header(),
+            groups_header: Self::default_groups_header(),
+            groups_claim: Self::default_groups_claim(),
+            group_scopes: std::collections::BTreeMap::new(),
+        }
+    }
+}
+
 /// OAuth 2.1 AS + RS configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AuthConfig {
@@ -277,9 +399,12 @@ pub struct AuthConfig {
     /// nested — intended for local dev clusters only.
     #[serde(default = "AuthConfig::default_enabled")]
     pub enabled: bool,
+    /// Auth facade backend: `local` (default) or `authentik`.
+    #[serde(default)]
+    pub provider: AuthProviderKind,
     /// argon2id-encoded master password (generate via `vmcp hash-password`).
-    /// Required when `enabled = true`; ignored otherwise. Defaults to empty so
-    /// a minimal `[auth] enabled = false` block parses without it.
+    /// Required when `enabled = true` and `provider = local`; optional for
+    /// Authentik (only needed if `/admin` Basic auth should stay available).
     #[serde(default)]
     pub master_password_argon2: String,
     /// JWT key ID exposed via JWKS.
@@ -287,7 +412,7 @@ pub struct AuthConfig {
     pub jwt_kid: String,
     /// JWKS rotation interval. Two-key window (current + previous) covers
     /// tokens issued just before rotation. Must be >= 2 * token_ttl_secs
-    /// when `enabled = true`.
+    /// when `enabled = true` and `provider = local`.
     #[serde(default = "AuthConfig::default_jwks_rotate_secs")]
     pub jwks_rotate_secs: u64,
     /// Access-token TTL.
@@ -324,6 +449,12 @@ pub struct AuthConfig {
     /// Override via `VMCP_AUTH__JWKS_PRIVATE_KEY_PEM_PATH`.
     #[serde(default)]
     pub jwks_private_key_pem_path: Option<PathBuf>,
+    /// Authentik settings when `provider = "authentik"`.
+    #[serde(default)]
+    pub authentik: AuthentikSettings,
+    /// `/admin` SPA auth: `none` | `basic` | `authentik` headers.
+    #[serde(default)]
+    pub admin: AdminAuthSettings,
 }
 
 impl AuthConfig {
@@ -351,6 +482,7 @@ impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             enabled: Self::default_enabled(),
+            provider: AuthProviderKind::Local,
             master_password_argon2: String::new(),
             jwt_kid: Self::default_jwt_kid(),
             jwks_rotate_secs: Self::default_jwks_rotate_secs(),
@@ -362,6 +494,8 @@ impl Default for AuthConfig {
             dcr_max_clients: 0,
             dcr_redirect_uri_allowlist: Vec::new(),
             jwks_private_key_pem_path: None,
+            authentik: AuthentikSettings::default(),
+            admin: AdminAuthSettings::default(),
         }
     }
 }
@@ -407,45 +541,106 @@ impl Settings {
         // the password hash and JWKS rotation window are unused. Skip both
         // checks — operators can leave master_password_argon2 empty.
         if self.auth.enabled {
-            if self.auth.master_password_argon2.is_empty() {
-                return Err(ConfigError::Validation(
-                    "auth.master_password_argon2 is required".into(),
-                ));
+            match self.auth.provider {
+                AuthProviderKind::Local => self.validate_local_auth()?,
+                AuthProviderKind::Authentik => self.validate_authentik_auth()?,
             }
-            if !self.auth.master_password_argon2.starts_with("$argon2") {
-                return Err(ConfigError::Validation(
-                    "auth.master_password_argon2 must be a PHC-encoded argon2 hash".into(),
-                ));
-            }
-            // Actually parse the PHC string. The prefix check above passes for
-            // the shipped placeholder (`…$REPLACE_ME`), whose trailing segment
-            // is not valid Base64 — that slips through boot and only blows up at
-            // the OAuth `/consent` step with a cryptic "invalid Base64 encoding".
-            // Fail fast here with an actionable message instead.
-            if let Err(e) =
-                argon2::password_hash::PasswordHash::new(&self.auth.master_password_argon2)
-            {
-                return Err(ConfigError::Validation(format!(
-                    "auth.master_password_argon2 is not a valid argon2 hash ({e}) — \
-                     generate one with `vmcp hash-password` and set it via \
-                     VMCP_AUTH__MASTER_PASSWORD_ARGON2 or the [auth] block"
-                )));
-            }
-            // Token TTL must fit in the rotation window: clients issued just before
-            // a rotation should still verify against `previous`.
-            if self.auth.jwks_rotate_secs < 2 * self.auth.token_ttl_secs {
-                return Err(ConfigError::Validation(format!(
-                    "auth.jwks_rotate_secs ({}) must be >= 2 * token_ttl_secs ({})",
-                    self.auth.jwks_rotate_secs, self.auth.token_ttl_secs
-                )));
-            }
-            if self.auth.clients_db_path.as_os_str().is_empty() {
-                return Err(ConfigError::Validation(
-                    "auth.clients_db_path must be set when auth.enabled = true".into(),
-                ));
-            }
+            self.validate_admin_auth()?;
         }
         Ok(())
+    }
+
+    fn validate_master_password_hash(&self) -> Result<(), ConfigError> {
+        if self.auth.master_password_argon2.is_empty() {
+            return Err(ConfigError::Validation(
+                "auth.master_password_argon2 is required".into(),
+            ));
+        }
+        if !self.auth.master_password_argon2.starts_with("$argon2") {
+            return Err(ConfigError::Validation(
+                "auth.master_password_argon2 must be a PHC-encoded argon2 hash".into(),
+            ));
+        }
+        // Actually parse the PHC string. The prefix check above passes for
+        // the shipped placeholder (`…$REPLACE_ME`), whose trailing segment
+        // is not valid Base64 — that slips through boot and only blows up at
+        // the OAuth `/consent` step with a cryptic "invalid Base64 encoding".
+        // Fail fast here with an actionable message instead.
+        if let Err(e) = argon2::password_hash::PasswordHash::new(&self.auth.master_password_argon2)
+        {
+            return Err(ConfigError::Validation(format!(
+                "auth.master_password_argon2 is not a valid argon2 hash ({e}) — \
+                 generate one with `vmcp hash-password` and set it via \
+                 VMCP_AUTH__MASTER_PASSWORD_ARGON2 or the [auth] block"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_local_auth(&self) -> Result<(), ConfigError> {
+        // Local AS consent always needs the master password.
+        self.validate_master_password_hash()?;
+        // Token TTL must fit in the rotation window: clients issued just before
+        // a rotation should still verify against `previous`.
+        if self.auth.jwks_rotate_secs < 2 * self.auth.token_ttl_secs {
+            return Err(ConfigError::Validation(format!(
+                "auth.jwks_rotate_secs ({}) must be >= 2 * token_ttl_secs ({})",
+                self.auth.jwks_rotate_secs, self.auth.token_ttl_secs
+            )));
+        }
+        if self.auth.clients_db_path.as_os_str().is_empty() {
+            return Err(ConfigError::Validation(
+                "auth.clients_db_path must be set when auth.enabled = true".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_authentik_auth(&self) -> Result<(), ConfigError> {
+        let ak = &self.auth.authentik;
+        if ak.issuer.is_empty() {
+            return Err(ConfigError::Validation(
+                "auth.authentik.issuer is required when auth.provider = authentik".into(),
+            ));
+        }
+        if ak.jwks_url.is_empty() {
+            return Err(ConfigError::Validation(
+                "auth.authentik.jwks_url is required when auth.provider = authentik".into(),
+            ));
+        }
+        if !ak.accept_bearer && !ak.forward_auth {
+            return Err(ConfigError::Validation(
+                "auth.authentik: at least one of accept_bearer or forward_auth must be true".into(),
+            ));
+        }
+        if ak.forward_auth && ak.group_scopes.is_empty() {
+            return Err(ConfigError::Validation(
+                "auth.authentik.group_scopes must map at least one group when forward_auth is enabled"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_admin_auth(&self) -> Result<(), ConfigError> {
+        match self.auth.admin.mode {
+            AdminAuthMode::None => Ok(()),
+            AdminAuthMode::Basic => {
+                // Basic admin needs a valid master hash (even under Authentik MCP).
+                // Local provider already validated the same hash — call is idempotent.
+                self.validate_master_password_hash()
+            }
+            AdminAuthMode::Authentik => {
+                if self.auth.admin.required_groups.is_empty() {
+                    return Err(ConfigError::Validation(
+                        "auth.admin.required_groups must list at least one group when \
+                         auth.admin.mode = authentik"
+                            .into(),
+                    ));
+                }
+                Ok(())
+            }
+        }
     }
 
     fn validate_common(&self) -> Result<(), ConfigError> {
@@ -920,5 +1115,108 @@ token_ttl_secs = 3600
         let s = load(Some(&tmp.0)).expect("loads");
         assert_eq!(s.gql.max_response_bytes, 2_097_152);
         assert_eq!(s.gql.response_cap_mode, CapMode::Truncate);
+    }
+
+    #[test]
+    fn authentik_provider_parses_without_master_password() {
+        let tmp = write_tmp(
+            r#"
+[auth]
+enabled = true
+provider = "authentik"
+
+[auth.admin]
+mode = "authentik"
+required_groups = ["mcp-admins"]
+
+[auth.authentik]
+issuer = "https://auth.example.com/application/o/mcp-internal/"
+jwks_url = "https://auth.example.com/application/o/mcp-internal/jwks/"
+audiences = ["https://mcp.example.com/mcp"]
+forward_auth = true
+accept_bearer = true
+group_scopes = { "mcp-users" = "mcp:use" }
+"#,
+        );
+        let s = load(Some(&tmp.0)).expect("authentik auth loads");
+        assert_eq!(s.auth.provider, AuthProviderKind::Authentik);
+        assert_eq!(s.auth.admin.mode, AdminAuthMode::Authentik);
+        assert!(s.auth.master_password_argon2.is_empty());
+        assert_eq!(
+            s.auth.authentik.issuer,
+            "https://auth.example.com/application/o/mcp-internal/"
+        );
+        assert_eq!(
+            s.auth
+                .authentik
+                .group_scopes
+                .get("mcp-users")
+                .map(String::as_str),
+            Some("mcp:use")
+        );
+    }
+
+    #[test]
+    fn authentik_requires_group_scopes_when_forward_auth() {
+        let tmp = write_tmp(
+            r#"
+[auth]
+provider = "authentik"
+
+[auth.admin]
+mode = "none"
+
+[auth.authentik]
+issuer = "https://auth.example.com/application/o/mcp-internal/"
+jwks_url = "https://auth.example.com/application/o/mcp-internal/jwks/"
+forward_auth = true
+"#,
+        );
+        let err = load(Some(&tmp.0)).unwrap_err().to_string();
+        assert!(
+            err.contains("group_scopes"),
+            "expected group_scopes validation, got: {err}"
+        );
+    }
+
+    #[test]
+    fn admin_basic_requires_master_even_under_authentik_mcp() {
+        let tmp = write_tmp(
+            r#"
+[auth]
+provider = "authentik"
+# admin.mode defaults to basic → needs master hash
+
+[auth.authentik]
+issuer = "https://auth.example.com/application/o/mcp-internal/"
+jwks_url = "https://auth.example.com/application/o/mcp-internal/jwks/"
+group_scopes = { "mcp-users" = "mcp:use" }
+"#,
+        );
+        let err = load(Some(&tmp.0)).unwrap_err().to_string();
+        assert!(
+            err.contains("master_password_argon2"),
+            "expected master hash required for admin.basic, got: {err}"
+        );
+    }
+
+    #[test]
+    fn admin_none_allows_authentik_mcp_without_master() {
+        let tmp = write_tmp(
+            r#"
+[auth]
+provider = "authentik"
+
+[auth.admin]
+mode = "none"
+
+[auth.authentik]
+issuer = "https://auth.example.com/application/o/mcp-internal/"
+jwks_url = "https://auth.example.com/application/o/mcp-internal/jwks/"
+group_scopes = { "mcp-users" = "mcp:use" }
+"#,
+        );
+        let s = load(Some(&tmp.0)).expect("admin.none + authentik mcp");
+        assert_eq!(s.auth.admin.mode, AdminAuthMode::None);
     }
 }

--- a/crates/vmcp/src/main.rs
+++ b/crates/vmcp/src/main.rs
@@ -156,12 +156,14 @@ async fn serve_http(
     };
     use tracing::{error, warn};
     use vmcp_auth::{
-        build_router as auth_router,
+        build_external_rs_router, build_router as auth_router,
         client_store::ClientStore,
         jwks::JwksManager,
         require_admin_scope, require_bearer,
         state::{AuthState, DcrPolicy},
+        AuthFacade, AuthentikAuth, AuthentikConfig, LocalAuth,
     };
+    use vmcp_config::{AdminAuthMode, AuthProviderKind};
     use vmcp_server::ProxyServer;
     use vmcp_upstream::UpstreamPool;
     use vmcp_watch::spawn_file_watcher;
@@ -186,11 +188,13 @@ async fn serve_http(
     #[cfg(feature = "admin")]
     let bus = ctx.bus.clone();
 
+    let use_local_as = cfg.auth.enabled && cfg.auth.provider == AuthProviderKind::Local;
+
     let jwks = JwksManager::open(
         &cfg.auth.jwt_kid,
         cfg.auth.jwks_private_key_pem_path.as_deref(),
     )?;
-    let _rotation = if cfg.auth.enabled {
+    let _rotation = if use_local_as {
         Some(jwks.clone().spawn_rotation_task(
             Duration::from_secs(cfg.auth.jwks_rotate_secs),
             cfg.auth.jwt_kid.clone(),
@@ -208,7 +212,7 @@ async fn serve_http(
     let mut auth_state = AuthState::new(
         jwks.clone(),
         cfg.effective_issuer().to_string(),
-        resource_audience,
+        resource_audience.clone(),
         cfg.auth.token_ttl_secs,
         cfg.auth.master_password_argon2.clone(),
     )
@@ -222,7 +226,7 @@ async fn serve_http(
             auth_state.with_extra_resource_audiences(vec![format!("{base}{}", cfg.proxy.mcp_path)]);
     }
 
-    if cfg.auth.enabled {
+    if use_local_as {
         let store = ClientStore::open(&cfg.auth.clients_db_path).with_context(|| {
             format!(
                 "open DCR clients sqlite db at {}",
@@ -232,7 +236,7 @@ async fn serve_http(
         auth_state = auth_state.with_client_store(std::sync::Arc::new(store))?;
     }
 
-    let _token_watcher = if cfg.auth.enabled {
+    let _token_watcher = if use_local_as {
         if let Some(path) = cfg.auth.tokens_file.clone() {
             let store = static_tokens::StaticTokenStore::load(&path)?;
             auth_state = auth_state.with_token_store(store.clone());
@@ -256,6 +260,48 @@ async fn serve_http(
         } else {
             None
         }
+    } else {
+        None
+    };
+
+    // Auth facade: local OAuth AS/RS or Authentik (OIDC JWT + forward-auth).
+    let auth_facade: Option<AuthFacade> = if cfg.auth.enabled {
+        Some(match cfg.auth.provider {
+            AuthProviderKind::Local => {
+                info!(target: "vmcp::auth", provider = "local", "auth facade: local OAuth AS/RS");
+                AuthFacade::Local(LocalAuth::new(auth_state.clone()))
+            }
+            AuthProviderKind::Authentik => {
+                let ak = &cfg.auth.authentik;
+                let mut audiences = ak.audiences.clone();
+                if audiences.is_empty() {
+                    audiences.push(resource_audience.clone());
+                    if cfg.proxy.enabled {
+                        audiences.push(format!("{base}{}", cfg.proxy.mcp_path));
+                    }
+                }
+                info!(
+                    target: "vmcp::auth",
+                    provider = "authentik",
+                    issuer = %ak.issuer,
+                    forward_auth = ak.forward_auth,
+                    accept_bearer = ak.accept_bearer,
+                    "auth facade: Authentik OIDC resource server"
+                );
+                AuthFacade::Authentik(AuthentikAuth::new(AuthentikConfig {
+                    issuer: ak.issuer.clone(),
+                    jwks_url: ak.jwks_url.clone(),
+                    audiences,
+                    resource: resource_audience.clone(),
+                    accept_bearer: ak.accept_bearer,
+                    forward_auth: ak.forward_auth,
+                    username_header: ak.username_header.clone(),
+                    groups_header: ak.groups_header.clone(),
+                    groups_claim: ak.groups_claim.clone(),
+                    group_scopes: ak.group_scopes.clone(),
+                })?)
+            }
+        })
     } else {
         None
     };
@@ -369,11 +415,8 @@ async fn serve_http(
                 },
                 mcp_capture::capture_mcp,
             ));
-    if cfg.auth.enabled {
-        mcp_router = mcp_router.layer(middleware::from_fn_with_state(
-            auth_state.clone(),
-            require_bearer,
-        ));
+    if let Some(facade) = auth_facade.clone() {
+        mcp_router = mcp_router.layer(middleware::from_fn_with_state(facade, require_bearer));
     }
 
     #[derive(Clone)]
@@ -424,10 +467,21 @@ async fn serve_http(
     };
 
     let mut app = Router::new()
-        .merge(auth_router(auth_state.clone()))
         .route("/health", get(|| async { "ok" }))
         .route("/ready", get(ready_handler).with_state(ready_state))
         .nest(&cfg.mcp_path, mcp_router);
+
+    // Local AS mounts full OAuth surface; Authentik mode only advertises PRM
+    // pointing at the external authorization server.
+    if use_local_as {
+        app = app.merge(auth_router(auth_state.clone()));
+    } else if let Some(AuthFacade::Authentik(ref ak)) = auth_facade {
+        app = app.merge(build_external_rs_router(
+            ak.resource.clone(),
+            vec![ak.issuer.clone()],
+            ak.audiences.clone(),
+        ));
+    }
 
     // Registry hot-reload (file watcher + /api/v1/upstreams/reload).
     let reload_handle = RegistryReloadHandle::new(
@@ -470,7 +524,9 @@ async fn serve_http(
     };
 
     // Operator control-plane (Bearer + mcp:admin). Parallel to `/admin` Basic SPA.
-    if cfg.auth.enabled {
+    // Token CRUD needs local static tokens_file — skip under Authentik-only mode
+    // unless a tokens_file is still configured with local facade (local only).
+    if use_local_as {
         let reload = reload_handle.clone();
         let pool_status = reload_handle.pool();
         let api_state = ApiV1State::new(auth_state.clone(), cfg.auth.tokens_file.clone())
@@ -479,31 +535,67 @@ async fn serve_http(
                 Box::pin(async move { reload.reload().await })
             }))
             .with_pool(pool_status);
+        let facade = auth_facade.clone().expect("local AS implies auth facade");
         let api_router = api_v1::router(api_state)
             .layer(middleware::from_fn(require_admin_scope))
-            .layer(middleware::from_fn_with_state(
-                auth_state.clone(),
-                require_bearer,
-            ));
+            .layer(middleware::from_fn_with_state(facade, require_bearer));
         app = app.nest("/api/v1", api_router);
     }
 
     #[cfg(feature = "admin")]
     {
-        let admin_state = vmcp_admin::AdminState::new(
-            pool.clone(),
-            schema_swap.clone(),
-            bus.clone(),
-            skills.clone(),
-            cfg.skills_dir.clone(),
-            cfg.auth.master_password_argon2.clone(),
-            auth_state.clone(),
-            registry.clone(),
-            recorder.clone(),
-        );
-        let admin_router = vmcp_admin::router(admin_state);
+        // `/admin` mounts whenever auth is enabled; gate mode is independent of
+        // the MCP facade: none | basic (login:pass) | authentik headers.
         if cfg.auth.enabled {
-            app = app.nest("/admin", admin_router);
+            let admin_policy = match cfg.auth.admin.mode {
+                AdminAuthMode::None => {
+                    warn!(
+                        target: "vmcp::auth",
+                        "auth.admin.mode = none — /admin is unauthenticated"
+                    );
+                    vmcp_admin::AdminAuthPolicy::None
+                }
+                AdminAuthMode::Basic => vmcp_admin::AdminAuthPolicy::Basic,
+                AdminAuthMode::Authentik => {
+                    let user_h = cfg
+                        .auth
+                        .admin
+                        .username_header
+                        .as_deref()
+                        .unwrap_or(cfg.auth.authentik.username_header.as_str());
+                    let groups_h = cfg
+                        .auth
+                        .admin
+                        .groups_header
+                        .as_deref()
+                        .unwrap_or(cfg.auth.authentik.groups_header.as_str());
+                    vmcp_admin::AdminAuthPolicy::Authentik {
+                        username_header: axum::http::HeaderName::from_bytes(user_h.as_bytes())
+                            .context("auth.admin.username_header")?,
+                        groups_header: axum::http::HeaderName::from_bytes(groups_h.as_bytes())
+                            .context("auth.admin.groups_header")?,
+                        required_groups: cfg.auth.admin.required_groups.clone(),
+                    }
+                }
+            };
+            info!(
+                target: "vmcp::auth",
+                admin_mode = ?cfg.auth.admin.mode,
+                "admin auth facade"
+            );
+            let admin_state = vmcp_admin::AdminState::new(
+                pool.clone(),
+                schema_swap.clone(),
+                bus.clone(),
+                skills.clone(),
+                cfg.skills_dir.clone(),
+                cfg.auth.master_password_argon2.clone(),
+                auth_state.clone(),
+                registry.clone(),
+                recorder.clone(),
+            )
+            .with_admin_auth(admin_policy);
+            app = app.nest("/admin", vmcp_admin::router(admin_state));
         }
     }
 
@@ -537,11 +629,9 @@ async fn serve_http(
                 mcp_capture::capture_mcp,
             ),
         );
-        if cfg.auth.enabled {
-            proxy_router = proxy_router.layer(middleware::from_fn_with_state(
-                auth_state.clone(),
-                require_bearer,
-            ));
+        if let Some(facade) = auth_facade.clone() {
+            proxy_router =
+                proxy_router.layer(middleware::from_fn_with_state(facade, require_bearer));
         }
         info!(path = %cfg.proxy.mcp_path, "proxy mode enabled");
         app = app.nest(&cfg.proxy.mcp_path, proxy_router);

--- a/crates/vmcp/src/main.rs
+++ b/crates/vmcp/src/main.rs
@@ -374,6 +374,26 @@ async fn serve_http(
         });
     }
 
+    // Local OAuth AS: purge abandoned consent sessions + unused auth codes.
+    // Without this, `/authorize` abandons grow `AuthState::{consents,codes}` forever.
+    if use_local_as {
+        let auth = auth_state.clone();
+        let interval_secs = cfg.recorder.gc_interval_secs.max(1);
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            loop {
+                tick.tick().await;
+                let removed = auth.gc(vmcp_auth::AUTH_EPHEMERAL_MAX_AGE);
+                if removed > 0 {
+                    tracing::debug!(
+                        removed,
+                        "auth GC: purged expired OAuth codes/consent sessions"
+                    );
+                }
+            }
+        });
+    }
+
     let mut allowed_hosts: Vec<String> = vec!["localhost".into(), "127.0.0.1".into(), "::1".into()];
     if let Ok(url) = url::Url::parse(&cfg.public_base_url) {
         if let Some(h) = url.host_str() {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,7 +24,7 @@
 | Кто выдаёт токены | vmcp (DCR + PKCE + consent) | Authentik OAuth2/OIDC |
 | MCP-клиент | Bearer JWT или `vmcp_…` | Bearer JWT от Authentik |
 | Браузер за шлюзом | — | `X-authentik-username` + `X-authentik-groups` |
-| JWT verify | локальный JWKS | [`async-oidc-jwt-validator`](https://crates.io/crates/async-oidc-jwt-validator) + Authentik JWKS |
+| JWT verify | локальный JWKS | remote JWKS (rustls `reqwest`) + Authentik JWKS |
 | Local `/authorize`… | да | нет (только PRM → Authentik) |
 
 ### Authentik (рекомендуемая схема без DCR)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,21 +1,80 @@
 # Аутентификация
 
-`/mcp` (и `/mcp-proxy`) — OAuth 2.1 + PKCE + DCR, принимают Bearer JWT или static `vmcp_…` token. `/admin` — отдельно, **HTTP Basic** против master password (не bearer).
+`/mcp` (и `/mcp-proxy`) защищены через **auth facade**: либо встроенный OAuth 2.1 AS/RS (`provider = "local"`), либо внешний [Authentik](https://github.com/goauthentik/authentik) (`provider = "authentik"`). `/admin` — отдельный фасад с тремя режимами.
 
 ## Поверхности
 
 | Path | Auth | Назначение |
 | ---- | ---- | ---------- |
-| `/mcp` | Bearer JWT или `vmcp_…` | MCP streamable HTTP |
+| `/mcp` | Bearer JWT / `vmcp_…` / Authentik forward-auth | MCP streamable HTTP |
 | `/mcp-proxy` | то же (если `[proxy]`) | Transparent upstream tools |
-| `/admin` | HTTP Basic (master password) | Operator SPA |
+| `/admin` | `none` \| HTTP Basic \| Authentik headers | Operator SPA |
 | `/health` | нет | Liveness |
 | `/ready` | нет | Readiness (soft: ≥1 connected upstream, если в registry есть enabled) |
-| `/authorize`, `/consent`, `/token`, `/register`, `/.well-known/*` | нет | OAuth + metadata |
+| `/authorize`, `/consent`, `/token`, `/register`, `/.well-known/*` | нет | OAuth + metadata (local AS) |
 
 ---
 
-## OAuth flow
+## Auth facade: `local` vs `authentik`
+
+Одна точка входа (`AuthFacade`) на каждый защищённый запрос. Аноним / роль по умолчанию **никогда** не подставляются.
+
+| | `provider = "local"` (default) | `provider = "authentik"` |
+| - | --- | --- |
+| Кто выдаёт токены | vmcp (DCR + PKCE + consent) | Authentik OAuth2/OIDC |
+| MCP-клиент | Bearer JWT или `vmcp_…` | Bearer JWT от Authentik |
+| Браузер за шлюзом | — | `X-authentik-username` + `X-authentik-groups` |
+| JWT verify | локальный JWKS | [`async-oidc-jwt-validator`](https://crates.io/crates/async-oidc-jwt-validator) + Authentik JWKS |
+| Local `/authorize`… | да | нет (только PRM → Authentik) |
+
+### Authentik (рекомендуемая схема без DCR)
+
+```toml
+[auth]
+enabled = true
+provider = "authentik"
+# master_password_argon2 опционален — только если нужен /admin Basic
+
+[auth.authentik]
+issuer = "https://auth.example.com/application/o/mcp-internal/"
+jwks_url = "https://auth.example.com/application/o/mcp-internal/jwks/"
+# пусто → public_base_url + /mcp (+ /mcp-proxy)
+audiences = ["https://architecture.mcpwork.space/mcp"]
+accept_bearer = true          # MCP-клиенты
+forward_auth = true           # браузер за Envoy/Caddy forward-auth
+group_scopes = { "mcp-users" = "mcp:use", "mcp-admins" = "mcp:admin" }
+```
+
+Правила forward-auth:
+
+1. Нет `X-authentik-username` → отказ (не аноним).
+2. Группы режутся по `|`, `,`, `;`, пробелу; сравнение **точное** (`architect-x` ≠ `architect`).
+3. Scope из `group_scopes` считается на **каждом** запросе.
+
+Предпочтительно: pre-registered public client в Authentik + Authorization Code + PKCE (не DCR).
+
+### `/admin` auth: `none` | `basic` | `authentik`
+
+Независимо от MCP `provider`:
+
+| `auth.admin.mode` | Как пускает |
+| ----------------- | ----------- |
+| `none` | без проверки (только локально) |
+| `basic` (default) | HTTP Basic `login:password` → `master_password_argon2` |
+| `authentik` | заголовки `X-authentik-username` / `X-authentik-groups`; нужна точная группа из `required_groups` |
+
+```toml
+[auth.admin]
+mode = "authentik"
+required_groups = ["mcp-admins"]
+# username_header / groups_header — опционально; иначе из [auth.authentik]
+```
+
+При `mode = authentik`: нет username-заголовка → 401; группа сравнивается **точно** после split по `|`, `,`, `;`, пробелу (`architect-x` ≠ `architect`).
+
+---
+
+## OAuth flow (local)
 
 ```
 1. GET  /.well-known/oauth-authorization-server   # discovery

--- a/scripts/leak-check.sh
+++ b/scripts/leak-check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Leak check for vmcp-auth.
+#
+# 1) Static: AuthState::{codes,consents} GC must be scheduled from serve_http.
+# 2) Dynamic: nightly AddressSanitizer + LeakSanitizer on the lib test suite.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TARGET="${LEAK_TARGET:-x86_64-unknown-linux-gnu}"
+OUT_DIR="${LEAK_TARGET_DIR:-/tmp/vmcp-leak-check}"
+FILTER="${1:-}"
+
+echo "== [1/2] static: auth GC wiring =="
+rg -n "AUTH_EPHEMERAL_MAX_AGE" crates/vmcp-auth/src/state.rs >/dev/null
+rg -n 'auth\.gc\(vmcp_auth::AUTH_EPHEMERAL_MAX_AGE\)' crates/vmcp/src/main.rs \
+  || { echo "FAIL: serve_http must call AuthState::gc(AUTH_EPHEMERAL_MAX_AGE)"; exit 1; }
+echo "OK: AUTH_EPHEMERAL_MAX_AGE + background GC present"
+
+echo "== [2/2] dynamic: ASan/LSan (nightly, build-std) =="
+rustup toolchain install nightly --profile minimal -c rust-src >/dev/null
+export RUSTFLAGS="-Z sanitizer=address"
+# halt_on_error=1 fails the process on the first sanitizer error / leak summary.
+export ASAN_OPTIONS="detect_leaks=1:halt_on_error=1"
+export CARGO_TARGET_DIR="$OUT_DIR"
+
+cmd=(
+  cargo +nightly test -Z build-std
+  --target "$TARGET"
+  -p vmcp-auth --lib
+)
+if [[ -n "$FILTER" ]]; then
+  cmd+=("$FILTER")
+fi
+cmd+=(-- --test-threads=1)
+
+echo "+ CARGO_TARGET_DIR=$OUT_DIR RUSTFLAGS=$RUSTFLAGS ${cmd[*]}"
+"${cmd[@]}"
+echo "OK: vmcp-auth lib tests passed under AddressSanitizer/LeakSanitizer"

--- a/vmcp.toml
+++ b/vmcp.toml
@@ -31,8 +31,11 @@ call_timeout_ms  = 60000
 
 [auth]
 # enabled = true   # set false for local dev only — disables bearer on /mcp and hides /admin
+# provider = "local"       # default: built-in OAuth AS/RS
+# provider = "authentik"   # external Authentik (JWT + forward-auth); see docs/authentication.md
 # argon2id hash of the master password — generate with `vmcp hash-password`.
 # This default is the hash of "demo-master" for local dev only. ROTATE in prod.
+# Required for provider=local; optional for authentik (only if /admin Basic needed).
 master_password_argon2 = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8"
 jwt_kid          = "vmcp-2026-01"
 jwks_rotate_secs = 86400
@@ -45,6 +48,20 @@ issuer           = "http://localhost:8765"
 # Durable DCR client registry (SQLite, same idea as [tasks].db_path). Survives
 # gateway restart so Cursor can reuse its stored client_id. See docs/authentication.md.
 clients_db_path  = "./state/clients.db"
+
+# /admin SPA auth (independent of MCP provider):
+# [auth.admin]
+# mode = "basic"                 # none | basic | authentik
+# required_groups = ["mcp-admins"]  # when mode = authentik
+
+# Example Authentik block (only when provider = "authentik"):
+# [auth.authentik]
+# issuer = "https://auth.example.com/application/o/mcp-internal/"
+# jwks_url = "https://auth.example.com/application/o/mcp-internal/jwks/"
+# audiences = ["https://architecture.mcpwork.space/mcp"]
+# accept_bearer = true
+# forward_auth = true
+# group_scopes = { "mcp-users" = "mcp:use", "mcp-admins" = "mcp:admin" }
 
 [recorder]
 # Live MCP session list + exchange dumps (JSON under directories).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
MCP auth facade (`local` | `authentik`) plus independent admin auth (`none` | `basic` | `authentik`). Authentik path validates Bearer JWT via remote JWKS over **rustls** (no OpenSSL), optional forward-auth headers, exact group match. Local OAuth AS/RS unchanged for `local` mode.

Also: AuthState GC for abandoned codes/consents, coverage gates, docs, ADR.

## CI fix
Clippy on `vmcp-admin` (`derivable_impls`, `needless_return`) — fixed in latest commit.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI green on this PR (fmt / clippy / test / coverage)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5491f2da-b513-483b-aa76-4f9b3d03c7bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5491f2da-b513-483b-aa76-4f9b3d03c7bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

