### PR TITLE
Filter catalog by caller upstream: whitelist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,8 +3825,11 @@ dependencies = [
  "async-graphql",
  "rmcp",
  "serde_json",
+ "tokio",
  "tracing",
  "vmcp-auth",
+ "vmcp-notify",
+ "vmcp-registry",
  "vmcp-upstream",
 ]
 

--- a/crates/vmcp-auth/src/scopes.rs
+++ b/crates/vmcp-auth/src/scopes.rs
@@ -153,11 +153,6 @@ impl ScopePolicy {
         Err("scope lacks mcp:read / mcp:use".into())
     }
 
-    /// Whether this policy may use the given upstream at all (call grants).
-    pub fn allows_upstream(&self, server: &str) -> bool {
-        self.upstreams.is_empty() || self.upstreams.contains(server)
-    }
-
     /// Whitelist mode without `mcp:admin`: discovery surfaces must hide
     /// upstreams the caller cannot use (G25).
     pub fn filters_catalog(&self) -> bool {
@@ -211,8 +206,6 @@ mod tests {
         let p = ScopePolicy::parse("mcp:use upstream:time");
         assert!(p.authorize("time", "now", false).is_ok());
         assert!(p.authorize("postgres", "query", false).is_err());
-        assert!(p.allows_upstream("time"));
-        assert!(!p.allows_upstream("postgres"));
         assert!(p.filters_catalog());
         assert!(p.catalog_allows_upstream("time"));
         assert!(!p.catalog_allows_upstream("postgres"));

--- a/crates/vmcp-auth/src/scopes.rs
+++ b/crates/vmcp-auth/src/scopes.rs
@@ -64,6 +64,8 @@ pub fn validate_scope_string(scope: &str) -> Result<(), String> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopePolicy {
     pub full: bool,
+    /// `mcp:admin` — control-plane plus an unfiltered discovery catalogue.
+    pub admin: bool,
     pub read: bool,
     pub write: bool,
     /// When non-empty, only these upstream names are allowed.
@@ -76,6 +78,7 @@ impl ScopePolicy {
     /// Parse a space-separated OAuth scope string.
     pub fn parse(scope: &str) -> Self {
         let mut full = false;
+        let mut admin = false;
         let mut read = false;
         let mut write = false;
         let mut upstreams = HashSet::new();
@@ -83,7 +86,11 @@ impl ScopePolicy {
 
         for tok in scope.split_whitespace() {
             match tok {
-                "mcp:use" | SCOPE_ADMIN => full = true,
+                "mcp:use" => full = true,
+                SCOPE_ADMIN => {
+                    full = true;
+                    admin = true;
+                }
                 "mcp:read" => read = true,
                 "mcp:write" => {
                     read = true;
@@ -114,6 +121,7 @@ impl ScopePolicy {
 
         Self {
             full,
+            admin,
             read,
             write,
             upstreams,
@@ -145,9 +153,22 @@ impl ScopePolicy {
         Err("scope lacks mcp:read / mcp:use".into())
     }
 
-    /// Whether this policy may use the given upstream at all (for discovery filters).
+    /// Whether this policy may use the given upstream at all (call grants).
     pub fn allows_upstream(&self, server: &str) -> bool {
         self.upstreams.is_empty() || self.upstreams.contains(server)
+    }
+
+    /// Whitelist mode without `mcp:admin`: discovery surfaces must hide
+    /// upstreams the caller cannot use (G25).
+    pub fn filters_catalog(&self) -> bool {
+        !self.admin && !self.upstreams.is_empty()
+    }
+
+    /// Whether `server` may appear in `tools/list`, GraphQL `servers` /
+    /// `search` / prompts, and introspection. `mcp:admin` always sees the
+    /// full catalogue; callers without `upstream:*` tokens also do.
+    pub fn catalog_allows_upstream(&self, server: &str) -> bool {
+        !self.filters_catalog() || self.upstreams.contains(server)
     }
 }
 
@@ -165,7 +186,10 @@ mod tests {
     #[test]
     fn mcp_admin_is_full_access() {
         let p = ScopePolicy::parse("mcp:admin");
+        assert!(p.admin);
         assert!(p.authorize("time", "now", false).is_ok());
+        assert!(!p.filters_catalog());
+        assert!(p.catalog_allows_upstream("postgres"));
     }
 
     #[test]
@@ -189,6 +213,24 @@ mod tests {
         assert!(p.authorize("postgres", "query", false).is_err());
         assert!(p.allows_upstream("time"));
         assert!(!p.allows_upstream("postgres"));
+        assert!(p.filters_catalog());
+        assert!(p.catalog_allows_upstream("time"));
+        assert!(!p.catalog_allows_upstream("postgres"));
+    }
+
+    #[test]
+    fn admin_catalog_unfiltered_even_with_whitelist() {
+        let p = ScopePolicy::parse("mcp:admin upstream:time");
+        assert!(p.authorize("postgres", "query", false).is_err());
+        assert!(!p.filters_catalog());
+        assert!(p.catalog_allows_upstream("postgres"));
+    }
+
+    #[test]
+    fn mcp_use_without_whitelist_shows_full_catalog() {
+        let p = ScopePolicy::parse("mcp:use");
+        assert!(!p.filters_catalog());
+        assert!(p.catalog_allows_upstream("postgres"));
     }
 
     #[test]

--- a/crates/vmcp-graphql/Cargo.toml
+++ b/crates/vmcp-graphql/Cargo.toml
@@ -12,3 +12,8 @@ rmcp = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+vmcp-notify = { path = "../vmcp-notify" }
+vmcp-registry = { path = "../vmcp-registry" }

--- a/crates/vmcp-graphql/src/lib.rs
+++ b/crates/vmcp-graphql/src/lib.rs
@@ -12,7 +12,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_graphql::dynamic::{
-    Field, FieldFuture, FieldValue, InputValue, Object, Scalar, Schema, TypeRef,
+    Field, FieldFuture, FieldValue, InputValue, Object, ResolverContext, Scalar, Schema, TypeRef,
 };
 use async_graphql::{Name, Value as GqlValue};
 use serde_json::{Map, Value};
@@ -20,6 +20,14 @@ use serde_json::{Map, Value};
 use vmcp_upstream::{ResolvedTool, UpstreamPool};
 
 pub mod validation;
+
+/// Discovery surfaces honor the same `upstream:` whitelist as tool calls (G25).
+/// Missing policy (auth off) → full catalogue.
+fn catalog_allows(ctx: &ResolverContext<'_>, server: &str) -> bool {
+    ctx.data_opt::<vmcp_auth::ScopePolicy>()
+        .map(|p| p.catalog_allows_upstream(server))
+        .unwrap_or(true)
+}
 
 /// One prompt argument advertised in GraphQL skill discovery.
 #[derive(Debug, Clone)]
@@ -342,12 +350,19 @@ pub fn build_schema_with_prompts(
         query = query.field(Field::new(
             "servers",
             TypeRef::named_nn_list_nn("Server"),
-            move |_ctx| {
+            move |ctx| {
                 let pool = pool_s.clone();
+                let policy = ctx.data_opt::<vmcp_auth::ScopePolicy>().cloned();
                 FieldFuture::new(async move {
                     let mut nodes: Vec<ServerNode> = pool
                         .all_resolved()
                         .into_iter()
+                        .filter(|(name, _)| {
+                            policy
+                                .as_ref()
+                                .map(|p| p.catalog_allows_upstream(name))
+                                .unwrap_or(true)
+                        })
                         .map(|(name, tools)| {
                             let read_only_count =
                                 tools.iter().filter(|t| t.read_only).count() as i64;
@@ -379,6 +394,7 @@ pub fn build_schema_with_prompts(
                 TypeRef::named_nn_list_nn("SearchHit"),
                 move |ctx| {
                     let pool = pool_s.clone();
+                    let policy = ctx.data_opt::<vmcp_auth::ScopePolicy>().cloned();
                     FieldFuture::new(async move {
                         let q = ctx.args.try_get("q")?.string()?.to_lowercase();
                         let tokens: Vec<&str> = q.split_whitespace().collect();
@@ -387,6 +403,11 @@ pub fn build_schema_with_prompts(
                         }
                         let mut hits: Vec<(usize, SearchHitNode)> = Vec::new();
                         for (server, tools) in pool.all_resolved() {
+                            if let Some(p) = &policy {
+                                if !p.catalog_allows_upstream(&server) {
+                                    continue;
+                                }
+                            }
                             for t in tools {
                                 let hay = format!(
                                     "{} {}",
@@ -434,6 +455,7 @@ pub fn build_schema_with_prompts(
                 TypeRef::named_nn_list_nn("Notification"),
                 move |ctx| {
                     let pool = pool_n.clone();
+                    let policy = ctx.data_opt::<vmcp_auth::ScopePolicy>().cloned();
                     FieldFuture::new(async move {
                         let since = ctx
                             .args
@@ -451,6 +473,12 @@ pub fn build_schema_with_prompts(
                         let notifs = bus.replay_since(since, limit);
                         let nodes: Vec<FieldValue> = notifs
                             .into_iter()
+                            .filter(|n| {
+                                policy
+                                    .as_ref()
+                                    .map(|p| p.catalog_allows_upstream(&n.source))
+                                    .unwrap_or(true)
+                            })
                             .map(|n| {
                                 FieldValue::owned_any(NotificationNode {
                                     id: n.id,
@@ -622,11 +650,15 @@ pub fn build_schema_with_prompts(
         query = query.field(Field::new(
             "prompts",
             TypeRef::named_nn_list_nn("Prompt"),
-            move |_ctx| {
+            move |ctx| {
                 let list_h = list_h.clone();
+                let policy = ctx.data_opt::<vmcp_auth::ScopePolicy>().cloned();
                 FieldFuture::new(async move {
-                    let nodes: Vec<PromptNode> =
-                        list_h().into_iter().map(prompt_meta_to_node).collect();
+                    let nodes: Vec<PromptNode> = list_h()
+                        .into_iter()
+                        .filter(|meta| prompt_catalog_visible(meta, policy.as_ref()))
+                        .map(prompt_meta_to_node)
+                        .collect();
                     Ok(Some(FieldValue::list(
                         nodes.into_iter().map(FieldValue::owned_any),
                     )))
@@ -641,6 +673,7 @@ pub fn build_schema_with_prompts(
                 TypeRef::named_nn_list_nn("Prompt"),
                 move |ctx| {
                     let list_h = list_h.clone();
+                    let policy = ctx.data_opt::<vmcp_auth::ScopePolicy>().cloned();
                     FieldFuture::new(async move {
                         let q = ctx.args.try_get("q")?.string()?.to_lowercase();
                         let tokens: Vec<&str> = q.split_whitespace().collect();
@@ -649,6 +682,9 @@ pub fn build_schema_with_prompts(
                         }
                         let mut scored: Vec<(usize, PromptNode)> = Vec::new();
                         for meta in list_h() {
+                            if !prompt_catalog_visible(&meta, policy.as_ref()) {
+                                continue;
+                            }
                             let hay = format!("{} {}", meta.name, meta.description).to_lowercase();
                             let hits = tokens.iter().filter(|t| hay.contains(**t)).count();
                             if hits > 0 {
@@ -672,8 +708,18 @@ pub fn build_schema_with_prompts(
                 TypeRef::named_nn("PromptContent"),
                 move |ctx| {
                     let get_h = get_h.clone();
+                    let policy = ctx.data_opt::<vmcp_auth::ScopePolicy>().cloned();
                     FieldFuture::new(async move {
                         let name = ctx.args.try_get("name")?.string()?.to_string();
+                        if let Some((server, _)) = name.split_once("__") {
+                            if let Some(p) = &policy {
+                                if !p.catalog_allows_upstream(server) {
+                                    return Err(async_graphql::Error::new(format!(
+                                        "unknown prompt: {name}"
+                                    )));
+                                }
+                            }
+                        }
                         let args = match ctx.args.try_get("arguments") {
                             Ok(v) => {
                                 let gql = v.deserialize::<GqlValue>()?;
@@ -729,11 +775,7 @@ pub fn build_schema_with_prompts(
             let type_name = format!("{}Read", pascal_case(&server));
             builder = builder.register(obj);
             let field_name = camel_case(&server);
-            query = query.field(Field::new(
-                field_name,
-                TypeRef::named_nn(type_name),
-                |_ctx| FieldFuture::new(async { Ok(Some(FieldValue::owned_any(NamespaceMarker))) }),
-            ));
+            query = query.field(namespace_root_field(field_name, type_name, server.clone()));
         }
 
         if !writes.is_empty() {
@@ -748,11 +790,7 @@ pub fn build_schema_with_prompts(
             let type_name = format!("{}Write", pascal_case(&server));
             builder = builder.register(obj);
             let field_name = camel_case(&server);
-            mutation = mutation.field(Field::new(
-                field_name,
-                TypeRef::named_nn(type_name),
-                |_ctx| FieldFuture::new(async { Ok(Some(FieldValue::owned_any(NamespaceMarker))) }),
-            ));
+            mutation = mutation.field(namespace_root_field(field_name, type_name, server.clone()));
             had_mutation_ns = true;
         }
     }
@@ -771,6 +809,32 @@ pub fn build_schema_with_prompts(
 
 /// Marker for namespace fields whose children resolve themselves.
 struct NamespaceMarker;
+
+fn namespace_root_field(field_name: String, type_name: String, server: String) -> Field {
+    Field::new(
+        field_name.clone(),
+        TypeRef::named_nn(type_name),
+        move |ctx| {
+            let hidden = !catalog_allows(&ctx, &server);
+            let fname = field_name.clone();
+            FieldFuture::new(async move {
+                if hidden {
+                    return Err(async_graphql::Error::new(format!(
+                        "Unknown field \"{fname}\""
+                    )));
+                }
+                Ok(Some(FieldValue::owned_any(NamespaceMarker)))
+            })
+        },
+    )
+}
+
+fn prompt_catalog_visible(meta: &PromptMeta, policy: Option<&vmcp_auth::ScopePolicy>) -> bool {
+    match &meta.server {
+        None => true,
+        Some(s) => policy.map(|p| p.catalog_allows_upstream(s)).unwrap_or(true),
+    }
+}
 
 #[derive(Debug, Clone)]
 struct ToolCallNode {
@@ -1542,5 +1606,136 @@ mod tests {
         assert!(node.text.is_some());
         // `structured()` duplicates value into text as a JSON string — parse it.
         assert_eq!(node.json["slide"], json!(2));
+    }
+
+    fn ro_tool(server: &str, name: &str) -> ResolvedTool {
+        ResolvedTool {
+            server: server.into(),
+            name: name.into(),
+            description: Some(format!("{server} {name}")),
+            input_schema: json!({"type": "object"}),
+            read_only: true,
+            task_support: vmcp_registry::TaskSupportHint::Forbidden,
+        }
+    }
+
+    fn catalog_pool() -> std::sync::Arc<UpstreamPool> {
+        let bus = vmcp_notify::Bus::new(16);
+        let pool = std::sync::Arc::new(UpstreamPool::empty_for_test(bus));
+        pool.insert_synthetic_for_test(
+            "alpha",
+            Some("tenant A".into()),
+            vec![ro_tool("alpha", "ping")],
+        );
+        pool.insert_synthetic_for_test(
+            "beta",
+            Some("tenant B".into()),
+            vec![ro_tool("beta", "ping")],
+        );
+        pool
+    }
+
+    fn server_names(resp: &async_graphql::Response) -> Vec<String> {
+        resp.data
+            .clone()
+            .into_json()
+            .ok()
+            .and_then(|v| v["servers"].as_array().cloned())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|s| s["name"].as_str().map(str::to_string))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn servers_and_search_honor_upstream_whitelist() {
+        use async_graphql::Request;
+
+        let pool = catalog_pool();
+        let schema = build_schema(pool.all_resolved(), pool.clone(), SchemaLimits::default())
+            .expect("schema");
+        let policy = vmcp_auth::ScopePolicy::parse("mcp:use upstream:alpha");
+
+        let servers = schema
+            .execute(Request::new("{ servers { name } }").data(policy.clone()))
+            .await;
+        assert!(servers.errors.is_empty(), "{:?}", servers.errors);
+        let names = server_names(&servers);
+        assert_eq!(names, vec!["alpha".to_string()]);
+
+        let search = schema
+            .execute(Request::new("{ search(q: \"ping\") { server tool } }").data(policy.clone()))
+            .await;
+        assert!(search.errors.is_empty(), "{:?}", search.errors);
+        let hits = search.data.clone().into_json().unwrap()["search"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["server"], json!("alpha"));
+
+        let hidden = schema
+            .execute(Request::new("{ beta { ping { isError } } }").data(policy))
+            .await;
+        assert!(
+            !hidden.errors.is_empty()
+                || hidden
+                    .data
+                    .clone()
+                    .into_json()
+                    .ok()
+                    .and_then(|v| v.get("beta").cloned())
+                    .is_none(),
+            "beta namespace must not resolve: {:?}",
+            hidden
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_and_unscoped_see_full_catalog() {
+        use async_graphql::Request;
+
+        let pool = catalog_pool();
+        let schema = build_schema(pool.all_resolved(), pool.clone(), SchemaLimits::default())
+            .expect("schema");
+
+        for scope in ["mcp:admin", "mcp:use", "mcp:admin upstream:alpha"] {
+            let policy = vmcp_auth::ScopePolicy::parse(scope);
+            let servers = schema
+                .execute(Request::new("{ servers { name } }").data(policy))
+                .await;
+            let mut names = server_names(&servers);
+            names.sort();
+            assert_eq!(
+                names,
+                vec!["alpha".to_string(), "beta".to_string()],
+                "{scope}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn filtered_entries_omit_foreign_namespace_from_introspection() {
+        use async_graphql::Request;
+
+        let pool = catalog_pool();
+        let entries: Vec<_> = pool
+            .all_resolved()
+            .into_iter()
+            .filter(|(n, _)| n == "alpha")
+            .collect();
+        let schema = build_schema(entries, pool, SchemaLimits::default()).expect("schema");
+        let resp = schema
+            .execute(Request::new(
+                r#"{ __type(name: "Query") { fields { name } } }"#,
+            ))
+            .await;
+        let fields = resp.data.clone().into_json().unwrap()["__type"]["fields"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let names: Vec<&str> = fields.iter().filter_map(|f| f["name"].as_str()).collect();
+        assert!(names.contains(&"alpha"), "{names:?}");
+        assert!(!names.contains(&"beta"), "{names:?}");
     }
 }

--- a/crates/vmcp-server/src/lib.rs
+++ b/crates/vmcp-server/src/lib.rs
@@ -36,6 +36,7 @@ use rmcp::{
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use vmcp_graphql::{build_schema_with_prompts, SchemaLimits};
 use vmcp_upstream::UpstreamPool;
 
 pub use tasks::RUN_TASK_TOOL;
@@ -99,6 +100,10 @@ struct Inner {
     peers: Arc<DashMap<u64, Peer<RoleServer>>>,
     /// Monotonic id generator for `peers` keys.
     peer_seq: Arc<AtomicU64>,
+    /// Limits used when rebuilding a caller-scoped GraphQL schema (G25).
+    schema_limits: SchemaLimits,
+    /// Include `{server}__{prompt}` in GraphQL when `[proxy]` is on.
+    include_upstream_prompts: bool,
 }
 
 /// The gated `run_task` tool plus its SQLite-backed task runner.
@@ -284,6 +289,19 @@ impl VmcpServer {
         skills: SkillsHandle,
         tasks: Option<Arc<TaskRunner>>,
     ) -> Self {
+        Self::with_tasks_and_schema(schema, pool, skills, tasks, SchemaLimits::default(), false)
+    }
+
+    /// [`with_tasks`] plus the GraphQL limits / proxy-prompt flag used to
+    /// rebuild a caller-scoped schema when `upstream:` whitelist mode is on.
+    pub fn with_tasks_and_schema(
+        schema: SchemaHandle,
+        pool: Arc<UpstreamPool>,
+        skills: SkillsHandle,
+        tasks: Option<Arc<TaskRunner>>,
+        schema_limits: SchemaLimits,
+        include_upstream_prompts: bool,
+    ) -> Self {
         let tasks = tasks.map(|runner| RunTaskTool {
             runner,
             tool: build_run_task_tool(),
@@ -296,6 +314,8 @@ impl VmcpServer {
                 tasks,
                 peers: Arc::new(DashMap::new()),
                 peer_seq: Arc::new(AtomicU64::new(0)),
+                schema_limits,
+                include_upstream_prompts,
             }),
             tool_router: Self::tool_router(),
         }
@@ -379,6 +399,34 @@ impl VmcpServer {
     /// Task runner when native MCP tasks are enabled.
     pub fn task_runner(&self) -> Option<Arc<TaskRunner>> {
         self.inner.tasks.as_ref().map(|t| t.runner.clone())
+    }
+
+    /// GraphQL schema containing only namespaces the caller may see (G25).
+    fn scoped_schema(&self, policy: &vmcp_auth::ScopePolicy) -> Arc<Schema> {
+        let entries: Vec<_> = self
+            .inner
+            .pool
+            .all_resolved()
+            .into_iter()
+            .filter(|(name, _)| policy.catalog_allows_upstream(name))
+            .collect();
+        let prompts = prompt_source_handlers(
+            self.inner.skills.clone(),
+            self.inner.pool.clone(),
+            self.inner.include_upstream_prompts,
+        );
+        match build_schema_with_prompts(
+            entries,
+            self.inner.pool.clone(),
+            self.inner.schema_limits,
+            Some(prompts),
+        ) {
+            Ok(schema) => Arc::new(schema),
+            Err(e) => {
+                tracing::error!(error = %e, "scoped GraphQL schema build failed; using full schema");
+                self.inner.schema.load_full()
+            }
+        }
     }
 
     #[tool(
@@ -477,7 +525,11 @@ Args: `query` (required GraphQL document), `variables` (optional JSON object), `
             ))]));
         }
 
-        let schema_guard = self.inner.schema.load_full();
+        let policy = scope_policy_from_request_context(&context);
+        let schema_guard = match policy.as_ref() {
+            Some(p) if p.filters_catalog() => self.scoped_schema(p),
+            _ => self.inner.schema.load_full(),
+        };
         let mut req = Request::new(args.query);
         if let Some(vars) = args.variables {
             req = req.variables(async_graphql::Variables::from_json(vars));
@@ -485,7 +537,7 @@ Args: `query` (required GraphQL document), `variables` (optional JSON object), `
         if let Some(op) = args.operation_name {
             req = req.operation_name(op);
         }
-        if let Some(policy) = scope_policy_from_request_context(&context) {
+        if let Some(policy) = policy {
             req = req.data(policy);
         }
         if let Some(caller) = caller_identity_from_request_context(&context) {

--- a/crates/vmcp-server/src/prompt_proxy.rs
+++ b/crates/vmcp-server/src/prompt_proxy.rs
@@ -36,9 +36,18 @@ pub(crate) fn normalize_prompt_args(
 }
 
 /// Build the prefixed MCP prompt catalogue from the pool snapshot.
-pub(crate) fn catalogue_from_pool(pool: &UpstreamPool) -> Vec<Prompt> {
+/// `policy` hides upstreams the caller cannot see (G25); `None` lists all.
+pub(crate) fn catalogue_from_pool_filtered(
+    pool: &UpstreamPool,
+    policy: Option<&vmcp_auth::ScopePolicy>,
+) -> Vec<Prompt> {
     let mut prompts: Vec<Prompt> = Vec::new();
     for (server, list) in pool.all_prompts() {
+        if let Some(p) = policy {
+            if !p.catalog_allows_upstream(&server) {
+                continue;
+            }
+        }
         for p in list {
             prompts.push(prompt_from_resolved(&server, &p));
         }
@@ -146,7 +155,7 @@ mod tests {
                 }],
             }],
         );
-        let listed = catalogue_from_pool(&pool);
+        let listed = catalogue_from_pool_filtered(&pool, None);
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].name, "demo__greet");
         let args = listed[0].arguments.as_ref().unwrap();
@@ -157,6 +166,38 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .contains("[demo]"));
+    }
+
+    #[test]
+    fn catalogue_filtered_hides_foreign_upstreams() {
+        let bus = Bus::new(64);
+        let pool = UpstreamPool::empty_for_test(bus);
+        pool.insert_synthetic_prompts_for_test(
+            "alpha",
+            None,
+            vec![],
+            vec![ResolvedPrompt {
+                server: "alpha".into(),
+                name: "a".into(),
+                description: None,
+                arguments: vec![],
+            }],
+        );
+        pool.insert_synthetic_prompts_for_test(
+            "beta",
+            None,
+            vec![],
+            vec![ResolvedPrompt {
+                server: "beta".into(),
+                name: "b".into(),
+                description: None,
+                arguments: vec![],
+            }],
+        );
+        let policy = vmcp_auth::ScopePolicy::parse("mcp:use upstream:alpha");
+        let listed = catalogue_from_pool_filtered(&pool, Some(&policy));
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "alpha__a");
     }
 
     #[test]
@@ -212,7 +253,7 @@ mod tests {
                 arguments: vec![],
             }],
         );
-        let listed = catalogue_from_pool(&pool);
+        let listed = catalogue_from_pool_filtered(&pool, None);
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].name, "svc__bare");
         assert!(listed[0].arguments.is_none());

--- a/crates/vmcp-server/src/proxy.rs
+++ b/crates/vmcp-server/src/proxy.rs
@@ -23,7 +23,7 @@ use tracing::warn;
 use vmcp_upstream::UpstreamPool;
 
 use crate::prompt_proxy::{
-    catalogue_from_pool, inject_into_result, normalize_prompt_args, NAME_SEP,
+    catalogue_from_pool_filtered, inject_into_result, normalize_prompt_args, NAME_SEP,
 };
 
 #[derive(Clone)]
@@ -62,25 +62,13 @@ impl ServerHandler for ProxyServer {
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _ctx: RequestContext<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        let all = self.pool.all_resolved();
-        let mut tools: Vec<Tool> = Vec::with_capacity(all.iter().map(|(_, v)| v.len()).sum());
-        for (server, list) in all {
-            let server_desc = self.pool.description_of(&server);
-            for t in list {
-                let prefixed = format!("{server}{NAME_SEP}{}", t.name);
-                let description =
-                    build_description(&server, server_desc.as_deref(), t.description.as_deref());
-                let schema = into_schema_arc(&prefixed, &t.input_schema);
-                tools.push(Tool::new_with_raw(
-                    prefixed,
-                    description.map(Into::into),
-                    schema,
-                ));
-            }
-        }
-        Ok(ListToolsResult::with_all_items(tools))
+        let policy = crate::scope_policy_from_request_context(&ctx);
+        Ok(ListToolsResult::with_all_items(tools_from_pool(
+            &self.pool,
+            policy.as_ref(),
+        )))
     }
 
     async fn call_tool(
@@ -146,17 +134,18 @@ impl ServerHandler for ProxyServer {
     async fn list_prompts(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _ctx: RequestContext<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, McpError> {
-        Ok(ListPromptsResult::with_all_items(catalogue_from_pool(
-            &self.pool,
-        )))
+        let policy = crate::scope_policy_from_request_context(&ctx);
+        Ok(ListPromptsResult::with_all_items(
+            catalogue_from_pool_filtered(&self.pool, policy.as_ref()),
+        ))
     }
 
     async fn get_prompt(
         &self,
         request: GetPromptRequestParams,
-        _ctx: RequestContext<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<GetPromptResponse, McpError> {
         let (server, prompt) = request.name.split_once(NAME_SEP).ok_or_else(|| {
             McpError::invalid_params(
@@ -167,6 +156,15 @@ impl ServerHandler for ProxyServer {
                 None,
             )
         })?;
+
+        if let Some(policy) = crate::scope_policy_from_request_context(&ctx) {
+            if !policy.catalog_allows_upstream(server) {
+                return Err(McpError::invalid_params(
+                    format!("unknown prompt: {}", request.name),
+                    None,
+                ));
+            }
+        }
 
         let upstream = self
             .pool
@@ -182,6 +180,31 @@ impl ServerHandler for ProxyServer {
         let tools = self.pool.resolved(server).unwrap_or_default();
         Ok(inject_into_result(server, &tools, upstream).into())
     }
+}
+
+fn tools_from_pool(pool: &UpstreamPool, policy: Option<&vmcp_auth::ScopePolicy>) -> Vec<Tool> {
+    let all = pool.all_resolved();
+    let mut tools: Vec<Tool> = Vec::with_capacity(all.iter().map(|(_, v)| v.len()).sum());
+    for (server, list) in all {
+        if let Some(p) = policy {
+            if !p.catalog_allows_upstream(&server) {
+                continue;
+            }
+        }
+        let server_desc = pool.description_of(&server);
+        for t in list {
+            let prefixed = format!("{server}{NAME_SEP}{}", t.name);
+            let description =
+                build_description(&server, server_desc.as_deref(), t.description.as_deref());
+            let schema = into_schema_arc(&prefixed, &t.input_schema);
+            tools.push(Tool::new_with_raw(
+                prefixed,
+                description.map(Into::into),
+                schema,
+            ));
+        }
+    }
+    tools
 }
 
 fn build_description(
@@ -207,5 +230,47 @@ fn into_schema_arc(name: &str, raw: &Value) -> Arc<JsonObject> {
             );
             Arc::new(JsonObject::new())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmcp_notify::Bus;
+    use vmcp_registry::TaskSupportHint;
+    use vmcp_upstream::ResolvedTool;
+
+    #[test]
+    fn tools_from_pool_hides_foreign_upstreams() {
+        let bus = Bus::new(8);
+        let pool = UpstreamPool::empty_for_test(bus);
+        pool.insert_synthetic_for_test(
+            "alpha",
+            None,
+            vec![ResolvedTool {
+                server: "alpha".into(),
+                name: "echo".into(),
+                description: None,
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: true,
+                task_support: TaskSupportHint::Forbidden,
+            }],
+        );
+        pool.insert_synthetic_for_test(
+            "beta",
+            None,
+            vec![ResolvedTool {
+                server: "beta".into(),
+                name: "echo".into(),
+                description: None,
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: true,
+                task_support: TaskSupportHint::Forbidden,
+            }],
+        );
+        let policy = vmcp_auth::ScopePolicy::parse("mcp:use upstream:alpha");
+        let tools = tools_from_pool(&pool, Some(&policy));
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "alpha__echo");
     }
 }

--- a/crates/vmcp/src/boot.rs
+++ b/crates/vmcp/src/boot.rs
@@ -114,11 +114,21 @@ pub async fn boot(cfg: Settings) -> Result<BootContext> {
         None
     };
 
-    let vmcp_server = VmcpServer::with_tasks(
+    let vmcp_server = VmcpServer::with_tasks_and_schema(
         schema_swap.clone(),
         pool.clone(),
         skills.clone(),
         task_runner,
+        SchemaLimits {
+            max_depth: cfg.gql.max_depth,
+            max_complexity: cfg.gql.max_complexity,
+            max_response_bytes: cfg.gql.max_response_bytes,
+            response_cap_mode: match cfg.gql.response_cap_mode {
+                CapMode::Error => GqlCapMode::Error,
+                CapMode::Truncate => GqlCapMode::Truncate,
+            },
+        },
+        cfg.proxy.enabled,
     );
 
     // Notification forwarder is started from `serve_http` after

--- a/crates/vmcp/tests/catalog_g25.rs
+++ b/crates/vmcp/tests/catalog_g25.rs
@@ -12,8 +12,8 @@
 
 mod common;
 
-use rmcp::ClientHandler;
 use rmcp::model::*;
+use rmcp::ClientHandler;
 use vmcp_auth::static_tokens::{append_atomic, generate_entry};
 
 const DEMO_ARGON2: &str = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8";

--- a/crates/vmcp/tests/catalog_g25.rs
+++ b/crates/vmcp/tests/catalog_g25.rs
@@ -1,0 +1,383 @@
+//! E2E for catalog isolation (G25 / ADR 0002), walked in the same order as
+//! the operator docs:
+//!
+//! 1. [`docs/clients.md`] health + GraphQL discovery ladder
+//!    (`prompts` → `servers` → `search`/`searchPrompts` → `__type`)
+//! 2. [`docs/authentication.md`] static `pre-reg` scopes
+//! 3. [`docs/upstreams.md`] `/mcp-proxy` `tools/list`
+//! 4. [`docs/skills.md`] local YAML skill stays visible
+//! 5. [`docs/adr/0002-per-caller-catalog-visibility.md`] three caller rows
+//!
+//! Hand-checked against a live `vmcp serve` before this test was added.
+
+mod common;
+
+use rmcp::ClientHandler;
+use rmcp::model::*;
+use vmcp_auth::static_tokens::{append_atomic, generate_entry};
+
+const DEMO_ARGON2: &str = "$argon2id$v=19$m=19456,t=2,p=1$EKXF2yiUMT1injIS9ueldA$1Pra/zoGSKVIkZq1fCg0Hd2ceJuQn1H4k2lXeKUkMD8";
+
+#[derive(Clone, Default)]
+struct NullClient;
+
+impl ClientHandler for NullClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::default(),
+            Implementation::new("catalog-g25", "0.0.0"),
+        )
+    }
+}
+
+fn write_sidecar(dir: &std::path::Path, server: &str) {
+    let spec = serde_json::json!({
+        "server": server,
+        "tools": [
+            { "name": "delay_read", "read_only": true },
+            { "name": "delay_write", "read_only": false }
+        ]
+    });
+    std::fs::write(
+        dir.join("specs").join(format!("{server}.json")),
+        serde_json::to_vec_pretty(&spec).unwrap(),
+    )
+    .unwrap();
+}
+
+struct Tokens {
+    dayana: String,
+    admin: String,
+    unscoped: String,
+    admin_plus_whitelist: String,
+}
+
+fn setup_stand() -> (common::TempDir, std::path::PathBuf, Tokens) {
+    let dir = common::TempDir::new("vmcp-catalog-g25");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("state")).unwrap();
+    std::fs::create_dir_all(root.join("specs")).unwrap();
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+
+    // docs/skills.md — local YAML, no `server`; ADR 0002: always visible.
+    std::fs::write(
+        root.join("skills").join("search_docs.yaml"),
+        r#"name: search_docs
+description: Look up via GraphQL servers then search.
+template: |
+  Call query_graphql with:
+  { servers { name } }
+"#,
+    )
+    .unwrap();
+
+    write_sidecar(root, "dayana");
+    write_sidecar(root, "other");
+
+    let exe = env!("CARGO_BIN_EXE_mock_delay_upstream");
+    let registry = serde_json::json!({
+        "upstreams": [
+            {
+                "name": "dayana",
+                "description": "tenant dayana stand",
+                "transport": "stdio",
+                "command": exe,
+                "env": { "MOCK_LABEL": "dayana" },
+                "enabled": true,
+                "sidecar_spec": "dayana.json"
+            },
+            {
+                "name": "other",
+                "description": "tenant other stand",
+                "transport": "stdio",
+                "command": exe,
+                "env": { "MOCK_LABEL": "other" },
+                "enabled": true,
+                "sidecar_spec": "other.json"
+            }
+        ]
+    });
+    std::fs::write(
+        root.join("registry.json"),
+        serde_json::to_vec_pretty(&registry).unwrap(),
+    )
+    .unwrap();
+
+    // docs/authentication.md — `vmcp pre-reg --scope …`
+    let tokens_path = root.join("tokens.json");
+    let dayana = generate_entry("dayana", Some("mcp:use upstream:dayana")).unwrap();
+    let admin = generate_entry("ops", Some("mcp:admin")).unwrap();
+    let unscoped = generate_entry("bot", Some("mcp:use")).unwrap();
+    let admin_plus = generate_entry("ops2", Some("mcp:admin upstream:dayana")).unwrap();
+    append_atomic(&tokens_path, &dayana).unwrap();
+    append_atomic(&tokens_path, &admin).unwrap();
+    append_atomic(&tokens_path, &unscoped).unwrap();
+    append_atomic(&tokens_path, &admin_plus).unwrap();
+
+    let cfg = root.join("vmcp.toml");
+    std::fs::write(
+        &cfg,
+        format!(
+            r#"
+host = "127.0.0.1"
+public_base_url = "http://127.0.0.1:8765"
+registry_path = "{reg}"
+lock_path     = "{lock}"
+spec_dir      = "{spec}"
+skills_dir    = "{skills}"
+
+[gql]
+max_depth = 10
+max_complexity = 1000
+
+[upstream]
+spawn_timeout_ms = 30000
+call_timeout_ms  = 60000
+
+[auth]
+enabled = true
+master_password_argon2 = "{argon}"
+jwt_kid = "test"
+jwks_rotate_secs = 86400
+token_ttl_secs = 3600
+tokens_file = "{tokens}"
+clients_db_path = "{clients}"
+
+[proxy]
+enabled = true
+mcp_path = "/mcp-proxy"
+"#,
+            reg = root.join("registry.json").display(),
+            lock = root.join("tools.lock.json").display(),
+            spec = root.join("specs").display(),
+            skills = root.join("skills").display(),
+            argon = DEMO_ARGON2,
+            tokens = tokens_path.display(),
+            clients = root.join("state").join("clients.db").display(),
+        ),
+    )
+    .unwrap();
+
+    (
+        dir,
+        cfg,
+        Tokens {
+            dayana: dayana.token,
+            admin: admin.token,
+            unscoped: unscoped.token,
+            admin_plus_whitelist: admin_plus.token,
+        },
+    )
+}
+
+async fn connect(
+    url: String,
+    token: &str,
+) -> rmcp::service::RunningService<rmcp::RoleClient, NullClient> {
+    common::connect_client_with_token(NullClient, url, Some(token)).await
+}
+
+async fn gql_json(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, NullClient>,
+    query: &str,
+) -> serde_json::Value {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("query_graphql").with_arguments(
+                serde_json::json!({ "query": query })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("query_graphql");
+    for c in &result.content {
+        if let ContentBlock::Text(t) = c {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&t.text) {
+                return v;
+            }
+        }
+    }
+    panic!("query_graphql had no JSON text: {result:?}");
+}
+
+fn server_names(body: &serde_json::Value) -> Vec<String> {
+    body["data"]["servers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|s| s["name"].as_str().map(str::to_string))
+        .collect()
+}
+
+fn type_fields(body: &serde_json::Value) -> Vec<String> {
+    body["data"]["__type"]["fields"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|f| f["name"].as_str().map(str::to_string))
+        .collect()
+}
+
+#[tokio::test]
+async fn docs_catalog_g25_ladder() {
+    let (_dir, cfg, tokens) = setup_stand();
+    let gw = common::spawn_gateway_auth(&cfg).await;
+
+    // docs/clients.md — health is unauthenticated.
+    let health = reqwest::get(format!("http://127.0.0.1:{}/health", gw.port))
+        .await
+        .expect("health");
+    assert_eq!(health.text().await.unwrap().trim(), "ok");
+
+    // --- ADR 0002 row 1: whitelist, no mcp:admin ---
+    let tenant = connect(gw.mcp_url.clone(), &tokens.dayana).await;
+
+    // docs/skills.md + clients.md step 1: local YAML prompt.
+    let prompts = gql_json(&tenant, "{ prompts { name source server } }").await;
+    let prompt_names: Vec<&str> = prompts["data"]["prompts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|p| p["name"].as_str())
+        .collect();
+    assert_eq!(prompt_names, vec!["search_docs"]);
+    assert_eq!(prompts["data"]["prompts"][0]["source"], "local");
+
+    // clients.md step 2.
+    let servers = gql_json(
+        &tenant,
+        "{ servers { name description toolCount readOnlyCount } }",
+    )
+    .await;
+    assert_eq!(
+        server_names(&servers),
+        vec!["dayana".to_string()],
+        "whitelist must not list other: {servers}"
+    );
+
+    // clients.md step 3.
+    let search = gql_json(
+        &tenant,
+        r#"{ search(q: "delay") { server tool readOnly } }"#,
+    )
+    .await;
+    let hits = search["data"]["search"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(!hits.is_empty(), "{search}");
+    assert!(
+        hits.iter().all(|h| h["server"] == "dayana"),
+        "search leaked other: {search}"
+    );
+
+    let sp = gql_json(&tenant, r#"{ searchPrompts(q: "search") { name source } }"#).await;
+    assert_eq!(sp["data"]["searchPrompts"][0]["name"], "search_docs");
+
+    // clients.md step 4 — scoped schema, not only resolver filters.
+    let q_fields =
+        type_fields(&gql_json(&tenant, r#"{ __type(name: "Query") { fields { name } } }"#).await);
+    assert!(q_fields.contains(&"dayana".into()), "{q_fields:?}");
+    assert!(!q_fields.contains(&"other".into()), "{q_fields:?}");
+    let m_fields = type_fields(
+        &gql_json(
+            &tenant,
+            r#"{ __type(name: "Mutation") { fields { name } } }"#,
+        )
+        .await,
+    );
+    assert_eq!(m_fields, vec!["dayana".to_string()], "{m_fields:?}");
+
+    // docs/upstreams.md /mcp-proxy tools/list.
+    let proxy = connect(
+        format!("http://127.0.0.1:{}/mcp-proxy", gw.port),
+        &tokens.dayana,
+    )
+    .await;
+    let listed = proxy
+        .list_tools(Default::default())
+        .await
+        .expect("proxy list");
+    let proxy_names: Vec<String> = listed.tools.iter().map(|t| t.name.to_string()).collect();
+    assert!(
+        proxy_names.iter().any(|n| n.starts_with("dayana__")),
+        "{proxy_names:?}"
+    );
+    assert!(
+        proxy_names.iter().all(|n| !n.contains("other")),
+        "{proxy_names:?}"
+    );
+    proxy.cancel().await.ok();
+
+    // Call grant: own namespace works; foreign is unknown on scoped schema.
+    let ok = gql_json(&tenant, "{ dayana { delayRead(ms: 1) { isError text } } }").await;
+    assert_eq!(ok["data"]["dayana"]["delayRead"]["isError"], false, "{ok}");
+    let hidden = gql_json(&tenant, "{ other { delayRead(ms: 1) { isError text } } }").await;
+    let err = format!("{hidden}");
+    assert!(
+        err.contains("Unknown field") || err.contains("other"),
+        "foreign namespace must not resolve: {hidden}"
+    );
+    tenant.cancel().await.ok();
+
+    // --- ADR 0002 row 2: mcp:admin → full catalogue ---
+    let admin = connect(gw.mcp_url.clone(), &tokens.admin).await;
+    let mut admin_servers = server_names(&gql_json(&admin, "{ servers { name } }").await);
+    admin_servers.sort();
+    assert_eq!(
+        admin_servers,
+        vec!["dayana".to_string(), "other".to_string()]
+    );
+    let admin_q =
+        type_fields(&gql_json(&admin, r#"{ __type(name: "Query") { fields { name } } }"#).await);
+    assert!(admin_q.contains(&"dayana".into()) && admin_q.contains(&"other".into()));
+    admin.cancel().await.ok();
+
+    let admin_proxy = connect(
+        format!("http://127.0.0.1:{}/mcp-proxy", gw.port),
+        &tokens.admin,
+    )
+    .await;
+    let admin_listed = admin_proxy
+        .list_tools(Default::default())
+        .await
+        .expect("admin proxy");
+    let admin_proxy_names: Vec<String> = admin_listed
+        .tools
+        .iter()
+        .map(|t| t.name.to_string())
+        .collect();
+    assert!(admin_proxy_names.iter().any(|n| n.starts_with("dayana__")));
+    assert!(admin_proxy_names.iter().any(|n| n.starts_with("other__")));
+    admin_proxy.cancel().await.ok();
+
+    // --- ADR 0002 row 3: mcp:use without upstream:* → full catalogue ---
+    let god = connect(gw.mcp_url.clone(), &tokens.unscoped).await;
+    let mut god_servers = server_names(&gql_json(&god, "{ servers { name } }").await);
+    god_servers.sort();
+    assert_eq!(god_servers, vec!["dayana".to_string(), "other".to_string()]);
+    god.cancel().await.ok();
+
+    // Admin + whitelist: discovery full, calls still restricted (ADR 0002).
+    let mixed = connect(gw.mcp_url.clone(), &tokens.admin_plus_whitelist).await;
+    let mut mixed_servers = server_names(&gql_json(&mixed, "{ servers { name } }").await);
+    mixed_servers.sort();
+    assert_eq!(
+        mixed_servers,
+        vec!["dayana".to_string(), "other".to_string()],
+        "mcp:admin keeps full catalog even with upstream:dayana"
+    );
+    let mixed_call = gql_json(&mixed, "{ other { delayRead(ms: 1) { isError text } } }").await;
+    let mixed_text = format!("{mixed_call}");
+    assert!(
+        mixed_text.contains("forbidden")
+            || mixed_text.contains("upstream:other")
+            || mixed_call["data"]["other"]["delayRead"]["isError"] == true,
+        "admin+whitelist must still block calls to other: {mixed_call}"
+    );
+    mixed.cancel().await.ok();
+}

--- a/crates/vmcp/tests/scope_enforce.rs
+++ b/crates/vmcp/tests/scope_enforce.rs
@@ -82,7 +82,9 @@ async fn upstream_scope_blocks_other_server() {
     let dir = common::TempDir::new("vmcp-scope-enforce");
     let tokens = dir.path().join("tokens.json");
     let scoped = generate_entry("agent", Some("mcp:use upstream:alpha")).unwrap();
+    let admin = generate_entry("ops", Some("mcp:admin")).unwrap();
     append_atomic(&tokens, &scoped).unwrap();
+    append_atomic(&tokens, &admin).unwrap();
 
     let registry = serde_json::json!({
         "upstreams": [
@@ -137,6 +139,10 @@ jwks_rotate_secs = 86400
 token_ttl_secs = 3600
 tokens_file = "{tokens}"
 clients_db_path = "{clients}"
+
+[proxy]
+enabled = true
+mcp_path = "/mcp-proxy"
 "#,
             reg = dir.path().join("registry.json").display(),
             lock = dir.path().join("tools.lock.json").display(),
@@ -191,11 +197,124 @@ clients_db_path = "{clients}"
         .expect("beta call returns tool result");
     let denied_text = format!("{denied:?}");
     assert!(
-        denied_text.contains("forbidden") || denied_text.contains("upstream:beta"),
+        denied_text.contains("forbidden")
+            || denied_text.contains("upstream:beta")
+            || denied_text.contains("Unknown field"),
         "beta should be forbidden: {denied_text}"
     );
 
+    let catalog = gql_json(
+        &client,
+        "{ servers { name } search(q: \"echo\") { server tool } }",
+    )
+    .await;
+    let servers = catalog["data"]["servers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let server_names: Vec<&str> = servers.iter().filter_map(|s| s["name"].as_str()).collect();
+    assert_eq!(
+        server_names,
+        vec!["alpha"],
+        "whitelist catalog must not list beta: {catalog}"
+    );
+    let hits = catalog["data"]["search"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        hits.iter().all(|h| h["server"] == "alpha"),
+        "search leaked foreign upstream: {catalog}"
+    );
+
+    let intro = gql_json(
+        &client,
+        r#"{ __type(name: "Mutation") { fields { name } } }"#,
+    )
+    .await;
+    let intro_fields = intro["data"]["__type"]["fields"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let mut_fields: Vec<&str> = intro_fields
+        .iter()
+        .filter_map(|f| f["name"].as_str())
+        .collect();
+    assert!(
+        mut_fields.contains(&"alpha"),
+        "alpha mutation namespace missing: {intro}"
+    );
+    assert!(
+        !mut_fields.contains(&"beta"),
+        "beta mutation namespace leaked via introspection: {intro}"
+    );
+
+    let proxy = common::connect_client_with_token(
+        NullClient,
+        format!("http://127.0.0.1:{}/mcp-proxy", gw.port),
+        Some(&scoped.token),
+    )
+    .await;
+    let listed = proxy
+        .list_tools(Default::default())
+        .await
+        .expect("proxy list");
+    let names: Vec<String> = listed.tools.iter().map(|t| t.name.to_string()).collect();
+    assert!(
+        names.iter().any(|n| n.starts_with("alpha__")),
+        "proxy list missing alpha: {names:?}"
+    );
+    assert!(
+        names.iter().all(|n| !n.starts_with("beta__")),
+        "proxy list leaked beta: {names:?}"
+    );
+    proxy.cancel().await.ok();
+
+    let admin_client =
+        common::connect_client_with_token(NullClient, gw.mcp_url.clone(), Some(&admin.token)).await;
+    let admin_catalog = gql_json(&admin_client, "{ servers { name } }").await;
+    let admin_servers = admin_catalog["data"]["servers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let mut admin_names: Vec<&str> = admin_servers
+        .iter()
+        .filter_map(|s| s["name"].as_str())
+        .collect();
+    admin_names.sort();
+    assert_eq!(
+        admin_names,
+        vec!["alpha", "beta"],
+        "mcp:admin must see full catalog: {admin_catalog}"
+    );
+    admin_client.cancel().await.ok();
+
     client.cancel().await.ok();
+}
+
+async fn gql_json(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, NullClient>,
+    query: &str,
+) -> serde_json::Value {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("query_graphql").with_arguments(
+                serde_json::json!({ "query": query })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("query_graphql");
+    for c in &result.content {
+        if let ContentBlock::Text(t) = c {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&t.text) {
+                return v;
+            }
+        }
+    }
+    panic!("query_graphql had no JSON text: {result:?}");
 }
 
 #[derive(Clone, Default)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | [deployment.md](deployment.md) | Развертывание через GHCR: Compose + Caddy, bare metal, TLS, переменные окружения, чеклист |
 | [authentication.md](authentication.md) | Поток OAuth 2.1, master password, static tokens, Authentik hop trust, dev-режим без auth |
 | [adr/0001-forward-auth-trust-and-identity-propagation.md](adr/0001-forward-auth-trust-and-identity-propagation.md) | ADR: trust для `X-authentik-*` + `X-Vmcp-*` identity на HTTP upstream |
+| [adr/0002-per-caller-catalog-visibility.md](adr/0002-per-caller-catalog-visibility.md) | ADR: каталог по `upstream:<name>` whitelist (G25), не только вызовы |
 | [builds-and-modes.md](builds-and-modes.md) | Cargo features, release-бинарники, HTTP gateway, опциональный `[tasks]` |
 | [upstreams.md](upstreams.md) | Регистрация upstream-сервисов, tools (sidecar + lock) и prompts |
 | [tasks.md](tasks.md) | Нативные MCP Tasks (`run_task`), SQLite store, allowlist, поток SEP-1686 |

--- a/docs/adr/0002-per-caller-catalog-visibility.md
+++ b/docs/adr/0002-per-caller-catalog-visibility.md
@@ -63,3 +63,11 @@ group_scopes = { "dayana" = "mcp:use upstream:dayana", "admin" = "mcp:admin" }
 
 Token `mcp:use upstream:dayana` → `{ servers { name } }` is `[dayana]`.  
 Token `mcp:admin` → full `{ servers { name } }`.
+
+## Verification
+
+Same ladder as [clients.md](../clients.md) (`prompts` → `servers` → `search`/`searchPrompts` → `__type`), plus `/mcp-proxy` `tools/list` from [upstreams.md](../upstreams.md) and local YAML from [skills.md](../skills.md):
+
+```bash
+cargo test -p vmcp --test catalog_g25
+```

--- a/docs/adr/0002-per-caller-catalog-visibility.md
+++ b/docs/adr/0002-per-caller-catalog-visibility.md
@@ -1,0 +1,65 @@
+# ADR 0002 — Per-caller catalog visibility (G25)
+
+**Status:** Accepted  
+**Date:** 2026-08-19  
+**Context:** [hewimetall/vmcp#7](https://github.com/hewimetall/vmcp/issues/7) — multi-tenant gateway (vmcp 1.2.0 + Authentik groups). Call grants already used `upstream:<name>` whitelist; discovery still leaked every tenant namespace.
+
+## Problem
+
+One gateway served many isolated stands. Identity and call enforcement worked:
+
+- Authentik group → `group_scopes` → `upstream:<stand>`
+- `ScopePolicy::authorize` blocked `tools/call` / GraphQL resolvers / `run_task` for other stands
+
+The **catalogue was global**. A tenant who called GraphQL `{ servers { name } }`, `search(q)`, `__type(name: "Query"|"Mutation")`, or `/mcp-proxy` `tools/list` learned every other stand's upstream name. They could not *call* those tools, but names leaked.
+
+That blocked the topology the operators wanted: **one gateway per tenant, federated via `peerGatewayRef`**. Structural isolation only helps if the top-level catalog does not list every peer by name.
+
+A second, optional ask (lazy connect with caller identity on handshake) is **out of scope** here — see Consequences.
+
+## Decision
+
+Reuse the request-scoped `ScopePolicy` already attached to `/mcp` and `/mcp-proxy`. Do **not** invent a second ACL.
+
+| Caller | Catalogue |
+| ------ | --------- |
+| At least one `upstream:<name>` and **no** `mcp:admin` (whitelist mode) | Only those upstreams |
+| `mcp:admin` (even if `upstream:*` tokens are also present) | Full catalogue |
+| No `upstream:*` tokens (`mcp:use` / `mcp:read` / `mcp:write`) | Full catalogue — same as call grants |
+
+Surfaces that must honor the same predicate:
+
+- GraphQL `servers`, `search`, `prompts`, `searchPrompts`, `getPrompt`
+- GraphQL `notifications` (`source` is an upstream name)
+- GraphQL Query/Mutation **namespace fields** (resolver + scoped schema so `__type` / introspection do not list foreign fields)
+- `/mcp-proxy` `tools/list` and `prompts/list` (`prompts/get` for a hidden upstream → unknown)
+
+`mcp:use` without `upstream:*` is **not** tenant isolation. Those tokens may still call every namespace; hiding names would be theatre.
+
+Call enforcement is **unchanged**: `authorize` still applies the whitelist even for `mcp:admin` if `upstream:*` tokens are present. Admin's exception is discovery-only, so operators can inspect the full federated graph without widening tool grants.
+
+### Why a scoped GraphQL schema (not only resolver filters)
+
+Dynamic `async-graphql` fields have no `visible` hook. Filtering `servers` / `search` alone still leaves `__type(name: "Mutation") { fields { name } }` listing every tenant — the discovery ladder in `clients.md` tells agents to introspect Query/Mutation. For whitelist callers, `query_graphql` rebuilds a schema from the allowed `pool.all_resolved()` subset. Resolver filters remain as defence-in-depth (pool snapshot is still global).
+
+## Consequences
+
+- **Breaking for clients that assumed a global catalog** while holding `upstream:*` scopes: they stop seeing other namespaces. That is the point of #7.
+- Federated per-tenant gateways can advertise `peerGatewayRef` names only to callers who are scoped to them (or to `mcp:admin`).
+- Local YAML skills stay visible (no `server`); upstream `{server}__{prompt}` names follow the same whitelist.
+- Admin UI / `schema_swap` keep the full schema (operator surface).
+- **Not decided:** lazy upstream connect + `tools/list` with caller identity on first authorized use (#7 Ask 2). Boot still handshakes every enabled upstream anonymously. Catalog isolation does not require that change.
+
+## Example
+
+```toml
+[auth]
+enabled = true
+provider = "authentik"
+
+[auth.authentik]
+group_scopes = { "dayana" = "mcp:use upstream:dayana", "admin" = "mcp:admin" }
+```
+
+Token `mcp:use upstream:dayana` → `{ servers { name } }` is `[dayana]`.  
+Token `mcp:admin` → full `{ servers { name } }`.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -203,8 +203,12 @@ curl -H "Authorization: Bearer vmcp_…" https://gateway.example.com/mcp
 
 Пример: `--scope 'mcp:use upstream:time'` — агент не вызовет `postgres.*`.
 
-> **G25:** enforce режет **вызовы**. GraphQL schema / `search` / introspection пока могут
-> **показывать** чужие namespaces — не считать scopes полной изоляцией каталога.
+> **G25:** при whitelist (`upstream:<name>` без `mcp:admin`) каталог режется тем же
+> предикатом, что и вызовы: GraphQL `servers` / `search` / `prompts` /
+> `searchPrompts` / `__type` (namespace-поля Query/Mutation), GraphQL
+> `notifications.source`, и `/mcp-proxy` `tools/list` + `prompts/list`.
+> `mcp:admin` видит полный каталог. Без `upstream:*` токенов каталог по-прежнему
+> полный (как и call grants).
 
 > **G30:** DCR / OAuth consent **не** выдают `mcp:admin` (strips). Admin только через
 > `pre-reg` / `/api/v1/tokens` с operator Bearer.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -208,7 +208,7 @@ curl -H "Authorization: Bearer vmcp_…" https://gateway.example.com/mcp
 > `searchPrompts` / `__type` (namespace-поля Query/Mutation), GraphQL
 > `notifications.source`, и `/mcp-proxy` `tools/list` + `prompts/list`.
 > `mcp:admin` видит полный каталог. Без `upstream:*` токенов каталог по-прежнему
-> полный (как и call grants).
+> полный (как и call grants). Контракт: [ADR 0002](adr/0002-per-caller-catalog-visibility.md).
 
 > **G30:** DCR / OAuth consent **не** выдают `mcp:admin` (strips). Admin только через
 > `pre-reg` / `/api/v1/tokens` с operator Bearer.

--- a/docs/upstreams.md
+++ b/docs/upstreams.md
@@ -33,7 +33,7 @@ Env: `VMCP_REGISTRY_PATH`, `VMCP_SPEC_DIR`, `VMCP_LOCK_PATH`, `VMCP_SKILLS_DIR`,
 | Health | `connected` обновляется по RPC outcome; idle dead upstream без вызовов может долго казаться up (G24) |
 | `${ENV}` | Missing var → **ошибка** load registry (strict) |
 | Размер registry | Max **256** upstreams; duplicate `name` → ошибка |
-| Каталог (G25) | `upstream:<name>` whitelist режет `servers` / `search` / GraphQL schema / `/mcp-proxy` `tools/list`. `mcp:admin` — полный вид |
+| Каталог (G25) | `upstream:<name>` whitelist режет `servers` / `search` / GraphQL schema / `/mcp-proxy` `tools/list`. `mcp:admin` — полный вид. Контракт: [ADR 0002](adr/0002-per-caller-catalog-visibility.md) |
 
 ---
 

--- a/docs/upstreams.md
+++ b/docs/upstreams.md
@@ -33,6 +33,7 @@ Env: `VMCP_REGISTRY_PATH`, `VMCP_SPEC_DIR`, `VMCP_LOCK_PATH`, `VMCP_SKILLS_DIR`,
 | Health | `connected` обновляется по RPC outcome; idle dead upstream без вызовов может долго казаться up (G24) |
 | `${ENV}` | Missing var → **ошибка** load registry (strict) |
 | Размер registry | Max **256** upstreams; duplicate `name` → ошибка |
+| Каталог (G25) | `upstream:<name>` whitelist режет `servers` / `search` / GraphQL schema / `/mcp-proxy` `tools/list`. `mcp:admin` — полный вид |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes https://github.com/hewimetall/vmcp/issues/7 (Ask 1).

Multi-tenant gateways were already blocking **calls** with `upstream:<name>` scopes, but `tools/list`, GraphQL `servers` / `search`, and introspection still advertised every tenant namespace (G25).

Contract: [ADR 0002](docs/adr/0002-per-caller-catalog-visibility.md).

## What changed

When the caller has at least one `upstream:<name>` token (whitelist mode):

- GraphQL `servers`, `search`, `prompts`, `searchPrompts`, `getPrompt`, and `notifications` only include those upstreams
- Query/Mutation namespace fields for other servers fail as unknown, and `query_graphql` rebuilds a **scoped schema** so `__type(name: "Query"|"Mutation")` does not list them
- `/mcp-proxy` `tools/list` and `prompts/list` are filtered the same way; `prompts/get` for a hidden upstream returns unknown

`mcp:admin` keeps the full catalogue. Callers without `upstream:*` tokens are unchanged (they can already call every namespace).

Call enforcement is unchanged: whitelist still applies even on `mcp:admin` if those tokens are present; only **discovery** is unfiltered for admin.

Removed unused `ScopePolicy::allows_upstream` (G25 leftover: call grants already live in `authorize()`, catalog uses `catalog_allows_upstream`). Confirmed dead via agent-lsp `/lsp-dead-code` (test-only callers).

## Tests

- Unit: `ScopePolicy::catalog_allows_upstream` / `filters_catalog`
- Unit: GraphQL `servers` / `search` + introspection with filtered entries
- Unit: proxy `tools/list` / prompt catalogue filtering
- E2E: `crates/vmcp/tests/scope_enforce.rs` covers call deny, catalog hide, Mutation `__type`, proxy `tools/list`, and admin full view
- E2E: `crates/vmcp/tests/catalog_g25.rs` walks the operator docs ladder (`clients.md` health + `prompts` → `servers` → `search`/`searchPrompts` → `__type`, `authentication.md` `pre-reg` scopes, `upstreams.md` `/mcp-proxy` `tools/list`, `skills.md` local YAML, ADR 0002 three caller rows including `mcp:admin upstream:dayana`)

## Not in this PR

Ask 2 (optional lazy upstream connect on first authorized use, with caller identity on handshake) is left as a follow-up. Schema/catalog isolation is enough for the federated-per-tenant topology without leaking names.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b3afbf0-f336-48fb-b59f-1d91157f619f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b3afbf0-f336-48fb-b59f-1d91157f619f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

