### PR TITLE
feat(gql): optional GCF encoding for query_graphql output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcf"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0705a7940a7ad4f097e061709655b212a795299d39e6ec323e49d16021533ce8"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,6 +3872,7 @@ dependencies = [
  "async-graphql",
  "chrono",
  "dashmap",
+ "gcf",
  "handlebars 5.1.2",
  "http",
  "opentelemetry",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MCP gateway на Rust. Собирает несколько upstream MCP-серв
 - **Tasks (опционально)** — long-running tools как durable tasks на SQLite.
 - **OAuth 2.1 + PKCE + DCR** — или static bearer tokens.
 - **Hot-reload** — токены, `registry.json` и промпты обновляются без рестарта.
-- **GCF output (опционально)** — `[gql].gcf` кодирует `query_graphql` как [GCF](https://gcformat.com/) вместо JSON.
+- **GCF output (опционально)** — `[gql].gcf` для `query_graphql` (`/mcp`), `[proxy].gcf` для `/mcp-proxy`. [GCF](https://gcformat.com/) вместо JSON.
 - **`/api/v1`** — operator Token CRUD + upstreams reload (Bearer `mcp:admin`).
 
 ## Старт

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MCP gateway на Rust. Собирает несколько upstream MCP-серв
 - **Tasks (опционально)** — long-running tools как durable tasks на SQLite.
 - **OAuth 2.1 + PKCE + DCR** — или static bearer tokens.
 - **Hot-reload** — токены, `registry.json` и промпты обновляются без рестарта.
+- **GCF output (опционально)** — `[gql].gcf` кодирует `query_graphql` как [GCF](https://gcformat.com/) вместо JSON.
 - **`/api/v1`** — operator Token CRUD + upstreams reload (Bearer `mcp:admin`).
 
 ## Старт

--- a/crates/vmcp-config/src/lib.rs
+++ b/crates/vmcp-config/src/lib.rs
@@ -144,6 +144,11 @@ pub struct ProxyConfig {
     pub enabled: bool,
     #[serde(default = "ProxyConfig::default_mcp_path")]
     pub mcp_path: String,
+    /// Encode `/mcp-proxy` tool results as GCF generic profile
+    /// (<https://gcformat.com/>) instead of the upstream JSON/text.
+    /// Independent of `[gql].gcf`. Off by default. No-op unless `enabled`.
+    #[serde(default)]
+    pub gcf: bool,
 }
 
 impl Default for ProxyConfig {
@@ -151,6 +156,7 @@ impl Default for ProxyConfig {
         Self {
             enabled: false,
             mcp_path: Self::default_mcp_path(),
+            gcf: false,
         }
     }
 }
@@ -883,6 +889,7 @@ token_ttl_secs = 3600
         let s = load(Some(&tmp.0)).expect("loads");
         assert!(!s.proxy.enabled);
         assert_eq!(s.proxy.mcp_path, "/mcp-proxy");
+        assert!(!s.proxy.gcf);
     }
 
     #[test]
@@ -923,6 +930,33 @@ token_ttl_secs = 3600
         let s = load(Some(&tmp.0)).expect("loads");
         assert!(s.proxy.enabled);
         assert_eq!(s.proxy.mcp_path, "/mcp-raw");
+        assert!(!s.proxy.gcf);
+    }
+
+    #[test]
+    fn proxy_gcf_flag_independent_of_gql() {
+        let tmp = write_tmp(
+            r#"
+[gql]
+max_depth = 10
+max_complexity = 1000
+gcf = false
+
+[proxy]
+enabled = true
+gcf = true
+
+[auth]
+master_password_argon2 = "$argon2id$v=19$m=19456,t=2,p=1$YWFhYWFhYWFhYWFhYWFhYQ$dG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4"
+jwt_kid = "k1"
+jwks_rotate_secs = 86400
+token_ttl_secs = 3600
+"#,
+        );
+        let s = load(Some(&tmp.0)).expect("loads");
+        assert!(!s.gql.gcf);
+        assert!(s.proxy.enabled);
+        assert!(s.proxy.gcf);
     }
 
     #[test]

--- a/crates/vmcp-config/src/lib.rs
+++ b/crates/vmcp-config/src/lib.rs
@@ -236,6 +236,11 @@ pub struct GqlConfig {
     pub max_response_bytes: usize,
     #[serde(default)]
     pub response_cap_mode: CapMode,
+    /// Encode `query_graphql` tool text as GCF generic profile
+    /// (<https://gcformat.com/>) instead of JSON. Off by default.
+    /// Agents read GCF natively; typical GraphQL envelopes are 50–70% smaller.
+    #[serde(default)]
+    pub gcf: bool,
 }
 
 fn default_max_response_bytes() -> usize {
@@ -249,6 +254,7 @@ impl Default for GqlConfig {
             max_complexity: 1000,
             max_response_bytes: default_max_response_bytes(),
             response_cap_mode: CapMode::default(),
+            gcf: false,
         }
     }
 }
@@ -860,6 +866,7 @@ token_ttl_secs = 3600
         // Defaults kick in when neither field is set in TOML.
         assert_eq!(s.gql.max_response_bytes, 1_048_576);
         assert_eq!(s.gql.response_cap_mode, CapMode::Error);
+        assert!(!s.gql.gcf);
     }
 
     #[test]
@@ -1165,6 +1172,27 @@ token_ttl_secs = 3600
         let s = load(Some(&tmp.0)).expect("loads");
         assert_eq!(s.gql.max_response_bytes, 2_097_152);
         assert_eq!(s.gql.response_cap_mode, CapMode::Truncate);
+        assert!(!s.gql.gcf);
+    }
+
+    #[test]
+    fn gql_gcf_flag_reads_from_toml() {
+        let tmp = write_tmp(
+            r#"
+[gql]
+max_depth = 10
+max_complexity = 1000
+gcf = true
+
+[auth]
+master_password_argon2 = "$argon2id$v=19$m=19456,t=2,p=1$YWFhYWFhYWFhYWFhYWFhYQ$dG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4tdG9rZW4"
+jwt_kid = "k1"
+jwks_rotate_secs = 86400
+token_ttl_secs = 3600
+"#,
+        );
+        let s = load(Some(&tmp.0)).expect("loads");
+        assert!(s.gql.gcf);
     }
 
     #[test]

--- a/crates/vmcp-server/Cargo.toml
+++ b/crates/vmcp-server/Cargo.toml
@@ -35,6 +35,8 @@ parking_lot = { workspace = true }
 chrono = { workspace = true }
 rusqlite = { workspace = true }
 uuid = { workspace = true }
+# Optional compact query_graphql wire format (gated by [gql].gcf).
+gcf = "3.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/vmcp-server/src/gcf_out.rs
+++ b/crates/vmcp-server/src/gcf_out.rs
@@ -1,12 +1,14 @@
-//! Optional GCF encoding of `query_graphql` MCP tool text.
+//! Optional GCF encoding of MCP tool text.
 //!
-//! Gated by `[gql].gcf` (off by default). When on, the GraphQL JSON envelope
-//! is encoded as GCF generic profile (<https://gcformat.com/>) so agents see
-//! fewer tokens. Encode failure falls back to JSON so the call still returns.
+//! Two independent runtime flags:
+//! * `[gql].gcf` — GraphQL `/mcp` `query_graphql` envelope
+//! * `[proxy].gcf` — `/mcp-proxy` upstream tool results
+//!
+//! Both default off. Encode failure falls back to JSON so the call still returns.
 
 use std::borrow::Cow;
 
-use rmcp::model::Tool;
+use rmcp::model::{CallToolResult, ContentBlock, Tool};
 use serde_json::Value;
 
 /// Trailing sentence of the static `query_graphql` tool description.
@@ -18,10 +20,19 @@ pub const GCF_RETURNS: &str = "Returns the GraphQL envelope (`data` / `errors`) 
      profile (https://gcformat.com/), not JSON. Pipe-tabular GCF; models read it natively — \
      do not request JSON.";
 
-/// Extra line appended to server instructions when GCF output is on.
+/// Extra line appended to GraphQL server instructions when `[gql].gcf` is on.
 pub const GCF_INSTRUCTIONS: &str =
     "\n\nOutput: GCF generic profile (https://gcformat.com/), not JSON. \
      Same GraphQL `data`/`errors` envelope, pipe-tabular instead of braces.";
+
+/// Extra line appended to `/mcp-proxy` instructions when `[proxy].gcf` is on.
+pub const GCF_PROXY_INSTRUCTIONS: &str =
+    "\n\nOutput: GCF generic profile (https://gcformat.com/), not JSON. \
+     Structured / JSON tool results are encoded; plain-text errors stay as-is.";
+
+/// Suffix appended to proxied tool descriptions when `[proxy].gcf` is on.
+pub const GCF_PROXY_TOOL_NOTE: &str =
+    "\n\nOutput: GCF generic profile (https://gcformat.com/), not JSON.";
 
 /// Encode the GraphQL JSON envelope for the MCP tool text body.
 ///
@@ -60,6 +71,59 @@ pub fn annotate_query_graphql_tool(tool: &mut Tool) {
         format!("{desc}\n\n{GCF_RETURNS}")
     };
     tool.description = Some(Cow::Owned(rewritten));
+}
+
+/// Encode an upstream `CallToolResult` for `/mcp-proxy`.
+///
+/// When `gcf` is false the result is unchanged. When true:
+/// * `structuredContent` (if present) or JSON text is encoded as GCF
+/// * non-text blocks (image/audio) are kept
+/// * plain non-JSON text (errors, freeform) is left untouched
+pub fn encode_call_tool_result(mut result: CallToolResult, gcf: bool) -> CallToolResult {
+    if !gcf {
+        return result;
+    }
+    let payload = if let Some(sc) = result.structured_content.clone() {
+        sc
+    } else {
+        let text = result
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                ContentBlock::Text(t) => Some(t.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        match serde_json::from_str::<Value>(&text) {
+            Ok(v) => v,
+            Err(_) => return result,
+        }
+    };
+    let encoded = render_tool_text(&payload, true);
+    let mut content = vec![ContentBlock::text(encoded)];
+    content.extend(
+        result
+            .content
+            .iter()
+            .filter(|c| !matches!(c, ContentBlock::Text(_)))
+            .cloned(),
+    );
+    result.content = content;
+    result.structured_content = None;
+    result
+}
+
+/// Append the GCF note to a proxied tool description. Idempotent.
+pub fn annotate_proxy_tool_description(description: &mut Option<String>) {
+    let Some(desc) = description.as_mut() else {
+        *description = Some(GCF_PROXY_TOOL_NOTE.trim().to_string());
+        return;
+    };
+    if desc.contains("GCF generic profile") {
+        return;
+    }
+    desc.push_str(GCF_PROXY_TOOL_NOTE);
 }
 
 #[cfg(test)]
@@ -150,5 +214,81 @@ mod tests {
         let mut tool = dummy_tool("run_task", JSON_RETURNS);
         annotate_query_graphql_tool(&mut tool);
         assert_eq!(tool.description.as_deref(), Some(JSON_RETURNS));
+    }
+
+    fn text_of(result: &CallToolResult) -> String {
+        result
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                ContentBlock::Text(t) => Some(t.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn proxy_encode_off_is_passthrough() {
+        let original = CallToolResult::success(vec![ContentBlock::text(
+            json!({"timezone":"UTC"}).to_string(),
+        )]);
+        let out = encode_call_tool_result(original.clone(), false);
+        assert_eq!(out, original);
+    }
+
+    #[test]
+    fn proxy_encode_json_text() {
+        let body = json!({"timezone":"UTC","unix":1_700_000_000});
+        let result = CallToolResult::success(vec![ContentBlock::text(body.to_string())]);
+        let out = encode_call_tool_result(result, true);
+        let text = text_of(&out);
+        assert!(text.starts_with("GCF "), "{text}");
+        assert!(out.structured_content.is_none());
+        assert_eq!(gcf::decode_generic(&text).unwrap(), body);
+    }
+
+    #[test]
+    fn proxy_encode_prefers_structured_content() {
+        let structured = json!({"rows":[{"id":1},{"id":2}]});
+        let result = CallToolResult::structured(structured.clone());
+        let out = encode_call_tool_result(result, true);
+        let text = text_of(&out);
+        assert!(text.starts_with("GCF "), "{text}");
+        assert!(out.structured_content.is_none());
+        assert_eq!(gcf::decode_generic(&text).unwrap(), structured);
+    }
+
+    #[test]
+    fn proxy_encode_leaves_plain_text() {
+        let result = CallToolResult::error(vec![ContentBlock::text("forbidden: no scope")]);
+        let out = encode_call_tool_result(result.clone(), true);
+        assert_eq!(out, result);
+    }
+
+    #[test]
+    fn proxy_encode_keeps_non_text_blocks() {
+        let body = json!({"ok": true});
+        let mut result = CallToolResult::success(vec![ContentBlock::text(body.to_string())]);
+        result
+            .content
+            .push(ContentBlock::image("AAAA", "image/png"));
+        let out = encode_call_tool_result(result, true);
+        assert!(matches!(out.content[0], ContentBlock::Text(_)));
+        assert!(text_of(&out).starts_with("GCF "));
+        assert!(matches!(out.content[1], ContentBlock::Image(_)));
+    }
+
+    #[test]
+    fn annotate_proxy_description_appends_and_is_idempotent() {
+        let mut desc = Some("[time] get current time".into());
+        annotate_proxy_tool_description(&mut desc);
+        let once = desc.clone().unwrap();
+        assert!(once.contains("GCF generic profile"));
+        annotate_proxy_tool_description(&mut desc);
+        assert_eq!(desc.as_deref(), Some(once.as_str()));
+        let mut empty = None;
+        annotate_proxy_tool_description(&mut empty);
+        assert!(empty.unwrap().contains("GCF generic profile"));
     }
 }

--- a/crates/vmcp-server/src/gcf_out.rs
+++ b/crates/vmcp-server/src/gcf_out.rs
@@ -1,0 +1,154 @@
+//! Optional GCF encoding of `query_graphql` MCP tool text.
+//!
+//! Gated by `[gql].gcf` (off by default). When on, the GraphQL JSON envelope
+//! is encoded as GCF generic profile (<https://gcformat.com/>) so agents see
+//! fewer tokens. Encode failure falls back to JSON so the call still returns.
+
+use std::borrow::Cow;
+
+use rmcp::model::Tool;
+use serde_json::Value;
+
+/// Trailing sentence of the static `query_graphql` tool description.
+pub const JSON_RETURNS: &str =
+    "Returns the standard GraphQL response `{ \"data\": ..., \"errors\": ... }`.";
+
+/// Replacement for [`JSON_RETURNS`] when `[gql].gcf` is on.
+pub const GCF_RETURNS: &str = "Returns the GraphQL envelope (`data` / `errors`) as GCF generic \
+     profile (https://gcformat.com/), not JSON. Pipe-tabular GCF; models read it natively — \
+     do not request JSON.";
+
+/// Extra line appended to server instructions when GCF output is on.
+pub const GCF_INSTRUCTIONS: &str =
+    "\n\nOutput: GCF generic profile (https://gcformat.com/), not JSON. \
+     Same GraphQL `data`/`errors` envelope, pipe-tabular instead of braces.";
+
+/// Encode the GraphQL JSON envelope for the MCP tool text body.
+///
+/// When `gcf` is false this is `Value::to_string`. When true, GCF generic
+/// profile; if the encoder rejects the value (e.g. integer outside i64),
+/// JSON is returned so the agent still gets a payload.
+pub fn render_tool_text(body: &Value, gcf: bool) -> String {
+    if !gcf {
+        return body.to_string();
+    }
+    match gcf::encode_generic(body) {
+        Ok(text) => text,
+        Err(e) => {
+            tracing::warn!(error = %e, "GCF encode failed; falling back to JSON");
+            body.to_string()
+        }
+    }
+}
+
+/// Rewrite the advertised `query_graphql` description so the agent knows
+/// the wire format is GCF. Other tools are left untouched. Idempotent.
+pub fn annotate_query_graphql_tool(tool: &mut Tool) {
+    if tool.name.as_ref() != "query_graphql" {
+        return;
+    }
+    let Some(desc) = tool.description.as_deref() else {
+        tool.description = Some(Cow::Borrowed(GCF_RETURNS));
+        return;
+    };
+    if desc.contains("GCF generic profile") {
+        return;
+    }
+    let rewritten = if desc.contains(JSON_RETURNS) {
+        desc.replace(JSON_RETURNS, GCF_RETURNS)
+    } else {
+        format!("{desc}\n\n{GCF_RETURNS}")
+    };
+    tool.description = Some(Cow::Owned(rewritten));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Number};
+    use std::sync::Arc;
+
+    fn sample_envelope() -> Value {
+        json!({
+            "data": {
+                "time": {
+                    "getCurrentTime": {
+                        "isError": false,
+                        "json": {"timezone": "UTC", "unix": 1_700_000_000}
+                    }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn json_path_is_compact_json() {
+        let body = sample_envelope();
+        let out = render_tool_text(&body, false);
+        assert_eq!(out, body.to_string());
+        assert!(out.starts_with('{'), "json: {out}");
+        assert!(!out.starts_with("GCF"));
+    }
+
+    #[test]
+    fn gcf_path_is_generic_profile_and_roundtrips() {
+        let body = sample_envelope();
+        let out = render_tool_text(&body, true);
+        assert!(out.starts_with("GCF "), "expected GCF header, got: {out:?}");
+        assert!(out.contains("profile=generic"), "header: {out}");
+        let decoded = gcf::decode_generic(&out).expect("decode GCF");
+        assert_eq!(decoded, body);
+    }
+
+    #[test]
+    fn gcf_encode_failure_falls_back_to_json() {
+        // SPEC 2.3.2: integers outside i64 are rejected rather than approximated.
+        let body = Value::Number(Number::from(u64::MAX));
+        let out = render_tool_text(&body, true);
+        assert_eq!(out, body.to_string());
+        assert!(!out.starts_with("GCF "));
+    }
+
+    fn dummy_tool(name: &str, desc: &str) -> Tool {
+        Tool::new(
+            name.to_string(),
+            desc.to_string(),
+            Arc::new(Default::default()),
+        )
+    }
+
+    #[test]
+    fn annotate_rewrites_query_graphql_returns_line() {
+        let mut tool = dummy_tool("query_graphql", &format!("intro. {JSON_RETURNS}"));
+        annotate_query_graphql_tool(&mut tool);
+        let desc = tool.description.as_deref().unwrap().to_string();
+        assert!(desc.contains("GCF generic profile"));
+        assert!(!desc.contains(JSON_RETURNS));
+        // Idempotent.
+        annotate_query_graphql_tool(&mut tool);
+        assert_eq!(tool.description.as_deref(), Some(desc.as_str()));
+    }
+
+    #[test]
+    fn annotate_appends_when_returns_line_missing() {
+        let mut tool = dummy_tool("query_graphql", "just a blurb");
+        annotate_query_graphql_tool(&mut tool);
+        let desc = tool.description.as_deref().unwrap();
+        assert!(desc.contains("just a blurb"));
+        assert!(desc.contains("GCF generic profile"));
+    }
+
+    #[test]
+    fn annotate_fills_empty_description() {
+        let mut tool = Tool::new_with_raw("query_graphql", None, Arc::new(Default::default()));
+        annotate_query_graphql_tool(&mut tool);
+        assert_eq!(tool.description.as_deref(), Some(GCF_RETURNS));
+    }
+
+    #[test]
+    fn annotate_ignores_other_tools() {
+        let mut tool = dummy_tool("run_task", JSON_RETURNS);
+        annotate_query_graphql_tool(&mut tool);
+        assert_eq!(tool.description.as_deref(), Some(JSON_RETURNS));
+    }
+}

--- a/crates/vmcp-server/src/lib.rs
+++ b/crates/vmcp-server/src/lib.rs
@@ -54,6 +54,7 @@ pub use tasks::{collect_task_allowlist, TaskError, TaskRunner, TaskStore};
 pub mod proxy;
 pub use proxy::ProxyServer;
 
+pub mod gcf_out;
 pub mod graphql_inject;
 pub mod prompt_catalog;
 pub mod prompt_proxy;
@@ -94,6 +95,9 @@ struct Inner {
     /// Native MCP Tasks wiring. `Some` only when `[tasks].enabled` and the
     /// allowlist is non-empty — gates both `run_task` and the `tasks` capability.
     tasks: Option<RunTaskTool>,
+    /// Encode `query_graphql` tool text as GCF generic profile when true
+    /// (`[gql].gcf`). Off by default — JSON envelope.
+    gcf: bool,
     /// Connected client sessions, captured on `initialized`. The notification
     /// forwarder fans upstream MCP events out to these peers.
     peers: Arc<DashMap<u64, Peer<RoleServer>>>,
@@ -271,18 +275,20 @@ pub struct QueryGraphqlArgs {
 #[tool_router]
 impl VmcpServer {
     pub fn new(schema: SchemaHandle, pool: Arc<UpstreamPool>, skills: SkillsHandle) -> Self {
-        Self::with_tasks(schema, pool, skills, None)
+        Self::with_tasks(schema, pool, skills, None, false)
     }
 
     /// Like [`new`](Self::new) but wires the native-task `run_task` runner.
     /// Pass `Some(runner)` only when `[tasks].enabled` and the allowlist is
     /// non-empty — it registers `run_task` and turns on the server `tasks`
-    /// capability.
+    /// capability. `gcf` gates GCF encoding of `query_graphql` tool text
+    /// (`[gql].gcf`).
     pub fn with_tasks(
         schema: SchemaHandle,
         pool: Arc<UpstreamPool>,
         skills: SkillsHandle,
         tasks: Option<Arc<TaskRunner>>,
+        gcf: bool,
     ) -> Self {
         let tasks = tasks.map(|runner| RunTaskTool {
             runner,
@@ -294,6 +300,7 @@ impl VmcpServer {
                 pool,
                 skills,
                 tasks,
+                gcf,
                 peers: Arc::new(DashMap::new()),
                 peer_seq: Arc::new(AtomicU64::new(0)),
             }),
@@ -495,7 +502,7 @@ Args: `query` (required GraphQL document), `variables` (optional JSON object), `
         let body = serde_json::to_value(&resp)
             .unwrap_or_else(|e| json!({"errors": [{"message": format!("serialize: {e}")}]}));
         Ok(CallToolResult::success(vec![ContentBlock::text(
-            body.to_string(),
+            gcf_out::render_tool_text(&body, self.inner.gcf),
         )]))
     }
 }
@@ -561,7 +568,7 @@ impl ServerHandler for VmcpServer {
                 .get_or_insert_with(ExtensionCapabilities::new)
                 .insert(TASKS_EXTENSION_ID.to_string(), JsonObject::new());
         }
-        let instructions: String = if self.inner.tasks.is_some() {
+        let mut instructions: String = if self.inner.tasks.is_some() {
             "vmcp: Virtual MCP gateway.\n\
              \n\
              Tools:\n\
@@ -596,6 +603,9 @@ impl ServerHandler for VmcpServer {
              introspection."
                 .to_string()
         };
+        if self.inner.gcf {
+            instructions.push_str(gcf_out::GCF_INSTRUCTIONS);
+        }
         ServerInfo::new(caps)
             .with_server_info(impl_info)
             .with_instructions(instructions)
@@ -614,6 +624,11 @@ impl ServerHandler for VmcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = self.tool_router.list_all();
+        if self.inner.gcf {
+            for t in &mut tools {
+                gcf_out::annotate_query_graphql_tool(t);
+            }
+        }
         if let Some(t) = &self.inner.tasks {
             tools.push(t.tool.clone());
         }
@@ -624,7 +639,11 @@ impl ServerHandler for VmcpServer {
         if name == RUN_TASK_TOOL {
             return self.inner.tasks.as_ref().map(|d| d.tool.clone());
         }
-        self.tool_router.get(name).cloned()
+        let mut tool = self.tool_router.get(name).cloned()?;
+        if self.inner.gcf {
+            gcf_out::annotate_query_graphql_tool(&mut tool);
+        }
+        Some(tool)
     }
 
     async fn call_tool(

--- a/crates/vmcp-server/src/proxy.rs
+++ b/crates/vmcp-server/src/proxy.rs
@@ -29,11 +29,17 @@ use crate::prompt_proxy::{
 #[derive(Clone)]
 pub struct ProxyServer {
     pool: Arc<UpstreamPool>,
+    /// `[proxy].gcf` — encode upstream tool results as GCF generic profile.
+    gcf: bool,
 }
 
 impl ProxyServer {
     pub fn new(pool: Arc<UpstreamPool>) -> Self {
-        Self { pool }
+        Self::with_gcf(pool, false)
+    }
+
+    pub fn with_gcf(pool: Arc<UpstreamPool>, gcf: bool) -> Self {
+        Self { pool, gcf }
     }
 }
 
@@ -42,6 +48,17 @@ impl ServerHandler for ProxyServer {
         let mut impl_info = Implementation::from_build_env();
         impl_info.name = "vmcp-proxy".into();
         impl_info.version = env!("CARGO_PKG_VERSION").into();
+        let mut instructions = String::from(
+            "vmcp proxy: transparent passthrough of upstream MCP tools and prompts. \
+             Names are prefixed `{server}__{name}` to disambiguate across upstreams. \
+             Use `tools/list` / `prompts/list` to discover, then call/get by the \
+             prefixed name. Each prompts/get starts with a GraphQL routing table — \
+             call tools via `query_graphql` on the main `/mcp` endpoint when following \
+             playbooks (raw `tools/call` on this endpoint remains available).",
+        );
+        if self.gcf {
+            instructions.push_str(crate::gcf_out::GCF_PROXY_INSTRUCTIONS);
+        }
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
@@ -49,14 +66,7 @@ impl ServerHandler for ProxyServer {
                 .build(),
         )
         .with_server_info(impl_info)
-        .with_instructions(
-            "vmcp proxy: transparent passthrough of upstream MCP tools and prompts. \
-             Names are prefixed `{server}__{name}` to disambiguate across upstreams. \
-             Use `tools/list` / `prompts/list` to discover, then call/get by the \
-             prefixed name. Each prompts/get starts with a GraphQL routing table — \
-             call tools via `query_graphql` on the main `/mcp` endpoint when following \
-             playbooks (raw `tools/call` on this endpoint remains available).",
-        )
+        .with_instructions(instructions)
     }
 
     async fn list_tools(
@@ -70,8 +80,11 @@ impl ServerHandler for ProxyServer {
             let server_desc = self.pool.description_of(&server);
             for t in list {
                 let prefixed = format!("{server}{NAME_SEP}{}", t.name);
-                let description =
+                let mut description =
                     build_description(&server, server_desc.as_deref(), t.description.as_deref());
+                if self.gcf {
+                    crate::gcf_out::annotate_proxy_tool_description(&mut description);
+                }
                 let schema = into_schema_arc(&prefixed, &t.input_schema);
                 tools.push(Tool::new_with_raw(
                     prefixed,
@@ -122,7 +135,7 @@ impl ServerHandler for ProxyServer {
         self.pool
             .call(server, tool, args, caller.as_ref())
             .await
-            .map(Into::into)
+            .map(|r| crate::gcf_out::encode_call_tool_result(r, self.gcf).into())
             .map_err(|e| {
                 McpError::internal_error(format!("upstream `{server}` call failed: {e}"), None)
             })
@@ -133,8 +146,11 @@ impl ServerHandler for ProxyServer {
         let resolved = self.pool.resolved(server)?;
         let t = resolved.into_iter().find(|t| t.name == tool)?;
         let server_desc = self.pool.description_of(server);
-        let description =
+        let mut description =
             build_description(server, server_desc.as_deref(), t.description.as_deref());
+        if self.gcf {
+            crate::gcf_out::annotate_proxy_tool_description(&mut description);
+        }
         let schema = into_schema_arc(name, &t.input_schema);
         Some(Tool::new_with_raw(
             name.to_string(),

--- a/crates/vmcp/src/boot.rs
+++ b/crates/vmcp/src/boot.rs
@@ -119,6 +119,7 @@ pub async fn boot(cfg: Settings) -> Result<BootContext> {
         pool.clone(),
         skills.clone(),
         task_runner,
+        cfg.gql.gcf,
     );
 
     // Notification forwarder is started from `serve_http` after

--- a/crates/vmcp/src/main.rs
+++ b/crates/vmcp/src/main.rs
@@ -686,7 +686,7 @@ async fn serve_http(
     }
 
     if cfg.proxy.enabled {
-        let proxy_server = ProxyServer::new(pool.clone());
+        let proxy_server = ProxyServer::with_gcf(pool.clone(), cfg.proxy.gcf);
         let proxy_rmcp_config =
             StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts.clone());
         let proxy_rmcp_service = StreamableHttpService::new(

--- a/demo/vmcp.toml
+++ b/demo/vmcp.toml
@@ -17,6 +17,9 @@ notif_ring_max = 10000
 [gql]
 max_depth      = 10
 max_complexity = 1000
+# Encode query_graphql tool text as GCF (https://gcformat.com/) instead of JSON.
+# Off by default. Env: VMCP_GQL__GCF=true
+# gcf = true
 
 [upstream]
 spawn_timeout_ms = 120000

--- a/demo/vmcp.toml
+++ b/demo/vmcp.toml
@@ -44,3 +44,5 @@ gc_interval_secs = 30
 [proxy]
 enabled  = true
 mcp_path = "/mcp-proxy"
+# Encode /mcp-proxy tool results as GCF. Independent of [gql].gcf. Env: VMCP_PROXY__GCF=true
+# gcf = true

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -114,4 +114,6 @@ MCP-эндпоинт; секреты передавайте через пере�
 
 MCP tool text по умолчанию — компактный JSON envelope. Опциональный флаг
 `[gql].gcf = true` (env `VMCP_GQL__GCF`) кодирует тот же envelope как
-[GCF](https://gcformat.com/) generic profile. См. [builds-and-modes.md](builds-and-modes.md#gcf-output-query_graphql-опционально).
+[GCF](https://gcformat.com/) generic profile. Отдельный флаг `[proxy].gcf`
+(env `VMCP_PROXY__GCF`) делает то же для `/mcp-proxy`.
+См. [builds-and-modes.md](builds-and-modes.md#gcf-output-опционально-два-флага).

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -109,3 +109,9 @@ MCP-эндпоинт; секреты передавайте через пере�
   "bearer": "${REMOTE_MCP_TOKEN}"
 }
 ```
+
+## Формат ответа `query_graphql`
+
+MCP tool text по умолчанию — компактный JSON envelope. Опциональный флаг
+`[gql].gcf = true` (env `VMCP_GQL__GCF`) кодирует тот же envelope как
+[GCF](https://gcformat.com/) generic profile. См. [builds-and-modes.md](builds-and-modes.md#gcf-output-query_graphql-опционально).

--- a/docs/builds-and-modes.md
+++ b/docs/builds-and-modes.md
@@ -82,6 +82,7 @@ enabled = false
 | `auth.master_password_argon2` | `VMCP_AUTH__MASTER_PASSWORD_ARGON2` |
 | `upstream.spawn_timeout_ms` | `VMCP_UPSTREAM__SPAWN_TIMEOUT_MS` |
 | `auth.enabled` | `VMCP_AUTH__ENABLED` |
+| `gql.gcf` | `VMCP_GQL__GCF` |
 
 Итоговый конфиг: `vmcp print-config`.
 
@@ -133,6 +134,19 @@ max_concurrent = 16
 GraphQL (`query_graphql`) остаётся **sync**. Через `run_task` — только allowlisted task-capable tools. По умолчанию выключено.
 
 Env: `VMCP_TASKS__ENABLED=true`, `VMCP_TASKS__DB_PATH=…`.
+
+---
+
+## GCF output (`query_graphql`, опционально)
+
+По умолчанию `query_graphql` отдаёт стандартный GraphQL JSON `{ "data": ..., "errors": ... }`. Флаг `[gql].gcf` переключает **текст tool result** на [GCF](https://gcformat.com/) generic profile — тот же envelope, меньше токенов. Агенты читают GCF без priming. Если энкодер отклонит значение (например integer вне i64), vmcp откатится на JSON.
+
+```toml
+[gql]
+gcf = true
+```
+
+Env: `VMCP_GQL__GCF=true`. Когда флаг включён, `tools/list` и server instructions явно говорят, что ответ — GCF, не JSON. GraphQL-схема и поле `{ json }` внутри документа не меняются — компактируется только MCP text payload.
 
 ---
 

--- a/docs/builds-and-modes.md
+++ b/docs/builds-and-modes.md
@@ -83,6 +83,7 @@ enabled = false
 | `upstream.spawn_timeout_ms` | `VMCP_UPSTREAM__SPAWN_TIMEOUT_MS` |
 | `auth.enabled` | `VMCP_AUTH__ENABLED` |
 | `gql.gcf` | `VMCP_GQL__GCF` |
+| `proxy.gcf` | `VMCP_PROXY__GCF` |
 
 Итоговый конфиг: `vmcp print-config`.
 
@@ -137,16 +138,25 @@ Env: `VMCP_TASKS__ENABLED=true`, `VMCP_TASKS__DB_PATH=…`.
 
 ---
 
-## GCF output (`query_graphql`, опционально)
+## GCF output (опционально, два флага)
 
-По умолчанию `query_graphql` отдаёт стандартный GraphQL JSON `{ "data": ..., "errors": ... }`. Флаг `[gql].gcf` переключает **текст tool result** на [GCF](https://gcformat.com/) generic profile — тот же envelope, меньше токенов. Агенты читают GCF без priming. Если энкодер отклонит значение (например integer вне i64), vmcp откатится на JSON.
+[GCF](https://gcformat.com/) generic profile вместо JSON в MCP tool text. Флаги **независимые**, оба off by default. Энкодер отклонил значение (integer вне i64) → откат на JSON.
+
+| Флаг | Env | Где |
+| ---- | --- | --- |
+| `[gql].gcf` | `VMCP_GQL__GCF` | `/mcp` `query_graphql` envelope |
+| `[proxy].gcf` | `VMCP_PROXY__GCF` | `/mcp-proxy` `{server}__{tool}` results |
 
 ```toml
 [gql]
-gcf = true
+gcf = true          # только GraphQL /mcp
+
+[proxy]
+enabled = true
+gcf = true          # только /mcp-proxy; не требует [gql].gcf
 ```
 
-Env: `VMCP_GQL__GCF=true`. Когда флаг включён, `tools/list` и server instructions явно говорят, что ответ — GCF, не JSON. GraphQL-схема и поле `{ json }` внутри документа не меняются — компактируется только MCP text payload.
+`/mcp-proxy`: JSON text или `structuredContent` → GCF; plain-text ошибки не трогаем. Когда флаг включён, `tools/list` и server instructions говорят, что ответ — GCF.
 
 ---
 

--- a/docs/upstreams.md
+++ b/docs/upstreams.md
@@ -18,6 +18,7 @@
 | `[upstream].spawn_timeout_ms` | `30000` | Бюджет запуска |
 | `[upstream].call_timeout_ms` | `60000` | Бюджет одного вызова |
 | `[proxy].enabled` | off | Upstream-промпты + `/mcp-proxy` |
+| `[proxy].gcf` | off | GCF вместо JSON на `/mcp-proxy` (не зависит от `[gql].gcf`) |
 
 Env: `VMCP_REGISTRY_PATH`, `VMCP_SPEC_DIR`, `VMCP_LOCK_PATH`, `VMCP_SKILLS_DIR`, …
 Демо-стенд: [`demo/vmcp.toml`](../demo/vmcp.toml) + [`demo/README.md`](../demo/README.md)

--- a/vmcp.toml
+++ b/vmcp.toml
@@ -22,6 +22,9 @@ notif_ring_max = 10000
 [gql]
 max_depth      = 10
 max_complexity = 1000
+# Encode query_graphql tool text as GCF (https://gcformat.com/) instead of JSON.
+# Off by default. Agents read GCF natively; typically 50–70% fewer tokens.
+# gcf = true
 
 [upstream]
 # Cold uvx/npx first spawn can exceed 30s — keep both keys here (do not set

--- a/vmcp.toml
+++ b/vmcp.toml
@@ -87,6 +87,8 @@ gc_interval_secs = 30
 [proxy]
 enabled  = true
 mcp_path = "/mcp-proxy"
+# Encode /mcp-proxy tool results as GCF (https://gcformat.com/). Independent of [gql].gcf.
+# gcf = true
 
 # Optional native MCP Tasks (SEP-1686). Off by default.
 # When enabled, vmcp registers `run_task` for upstream tools with


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`query_graphql` still returns the GraphQL `{ data, errors }` envelope. This PR adds **two independent** runtime flags that encode MCP tool **text** as [GCF](https://gcformat.com/) generic profile instead of JSON.

Merged with `main` (catalog whitelist / G25, #8). Conflicts in `boot.rs` and `proxy.rs` resolved: scoped schema rebuild keeps `[gql].gcf`, `/mcp-proxy` `list_tools` keeps upstream filtering **and** GCF annotations.

## Flags (both off by default)

| Flag | Env | Surface |
| ---- | --- | ------- |
| `[gql].gcf` | `VMCP_GQL__GCF` | `/mcp` `query_graphql` |
| `[proxy].gcf` | `VMCP_PROXY__GCF` | `/mcp-proxy` `{server}__{tool}` |

```toml
[gql]
gcf = true          # GraphQL only

[proxy]
enabled = true
gcf = true          # proxy only; does not require [gql].gcf
```

When a flag is on:

- tool text is `gcf::encode_generic` of the JSON payload
- `tools/list` / server instructions tell the agent the wire format is GCF
- encode failure (e.g. integer outside i64) falls back to JSON
- `/mcp-proxy`: JSON text or `structuredContent` → GCF; plain-text errors pass through

GraphQL schema and `{ json }` fields inside the document are unchanged.

## Test plan

- [x] merge `origin/main`; conflicts resolved
- [x] config: `[gql].gcf` and `[proxy].gcf` independent
- [x] GraphQL encode JSON passthrough, GCF round-trip, fallback
- [x] proxy encode JSON text, structuredContent, plain-text skip, keep image blocks
- [x] catalog filter + GCF annotate on proxy `list_tools`
- [x] `cargo test --workspace --lib`
- [x] `cargo test -p vmcp --test catalog_g25 --test scope_enforce`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-332c2323-6c85-47ab-a179-64be7f390cb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-332c2323-6c85-47ab-a179-64be7f390cb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

